### PR TITLE
Fix out-of-bounds read in document.h

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -267,8 +267,9 @@ public:
 		RAPIDJSON_ASSERT(IsObject());
 
 		Object& o = data_.o;
+		size_t name_length = strlen(name);
 		for (Member* member = o.members; member != data_.o.members + data_.o.size; ++member)
-			if (name[member->name.data_.s.length] == '\0' && memcmp(member->name.data_.s.str, name, member->name.data_.s.length * sizeof(Ch)) == 0)
+			if (name_length == member->name.data_.s.length && memcmp(member->name.data_.s.str, name, member->name.data_.s.length * sizeof(Ch)) == 0)
 				return member;
 
 		return 0;


### PR DESCRIPTION
FindMember() compares length of "name" and "member->name.data_.s" via "name[member->name.data_.s.length] == '\0'", which can lead to reading past the length of "name". This patch stores the length of "name" (as determined by position of '\0') into "name_length" and changes the length comparison to be "name_length == "member->name.data_.s.length".
