### PR TITLE
drop trailing commas in enums

### DIFF
--- a/include/rapidjson/encodings.h
+++ b/include/rapidjson/encodings.h
@@ -448,7 +448,7 @@ enum UTFType {
 	kUTF16LE = 1,	//!< UTF-16 little endian.
 	kUTF16BE = 2,	//!< UTF-16 big endian.
 	kUTF32LE = 3,	//!< UTF-32 little endian.
-	kUTF32BE = 4,	//!< UTF-32 big endian.
+	kUTF32BE = 4	//!< UTF-32 big endian.
 };
 
 //! Dynamically select encoding according to stream's runtime-specified UTF encoding type.

--- a/include/rapidjson/rapidjson.h
+++ b/include/rapidjson/rapidjson.h
@@ -248,7 +248,7 @@ enum Type {
 	kObjectType = 3,	//!< object
 	kArrayType = 4,		//!< array 
 	kStringType = 5,	//!< string
-	kNumberType = 6,	//!< number
+	kNumberType = 6		//!< number
 };
 
 } // namespace rapidjson

--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -39,7 +39,7 @@ namespace rapidjson {
 enum ParseFlag {
 	kParseDefaultFlags = 0,			//!< Default parse flags. Non-destructive parsing. Text strings are decoded into allocated buffer.
 	kParseInsituFlag = 1,			//!< In-situ(destructive) parsing.
-	kParseValidateEncodingFlag = 2,	//!< Validate encoding of JSON strings.
+	kParseValidateEncodingFlag = 2	//!< Validate encoding of JSON strings.
 };
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
In C++'98/03, trailing commas in enumerations are not allowed, but have
been introduced in C++11.  This patch drops the trailing commas in order
to avoid compiler warnings (e.g. GCC with -pedantic).

Fixes http://code.google.com/p/rapidjson/issues/detail?id=49.
