### PR TITLE
GenericValue: fixup construction from NumberType

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -63,7 +63,7 @@ public:
 	GenericValue(Type type) {
 		static const unsigned defaultFlags[7] = {
 			kNullFlag, kFalseFlag, kTrueFlag, kObjectFlag, kArrayFlag, kConstStringFlag,
-			kNumberFlag | kIntFlag | kUintFlag | kInt64Flag | kUint64Flag | kDoubleFlag
+			kNumberAnyFlag
 		};
 		RAPIDJSON_ASSERT(type <= kNumberType);
 		flags_ = defaultFlags[type];
@@ -579,6 +579,7 @@ private:
 		kNumberInt64Flag = kNumberType | kNumberFlag | kInt64Flag,
 		kNumberUint64Flag = kNumberType | kNumberFlag | kUint64Flag,
 		kNumberDoubleFlag = kNumberType | kNumberFlag | kDoubleFlag,
+		kNumberAnyFlag = kNumberType | kNumberFlag | kIntFlag | kInt64Flag | kUintFlag | kUint64Flag | kDoubleFlag,
 		kConstStringFlag = kStringType | kStringFlag,
 		kCopyStringFlag = kStringType | kStringFlag | kCopyFlag,
 		kObjectFlag = kObjectType,


### PR DESCRIPTION
Constructing an empty GenericValue with a specific Type has failed
for any kNumberType (Int, Int64, Double...) due to incomplete definition
of the corresponding default flag value.

This patch adds a new constant kNumberAnyFlag to the flags enumeration
in GenericValue to cover this case.

This fixes http://code.google.com/p/rapidjson/issues/detail?id=57
