### PR TITLE
GenericDocument::ParseStream: make SourceEncoding optional

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -734,6 +734,11 @@ public:
 		return *this;
 	}
 
+	template <unsigned parseFlags, typename InputStream>
+	GenericDocument& ParseStream(InputStream& is) {
+		return ParseStream<parseFlags,Encoding,InputStream>(is);
+	}
+
 	//! Parse JSON text from a mutable string.
 	/*! \tparam parseFlags Combination of ParseFlag.
 		\param str Mutable zero-terminated string to be parsed.


### PR DESCRIPTION
The ParseStream() function current requires explicitly passing
the SourceEncoding parameter as explicit template argument
while the other Parse*() functions provide overloads to omit
this parameter and use the document's own encoding by default.

This patch adds the corresponding overload for ParseStream(),
enabling the simple usage again:

  rapidjson::FileStream is(fp);
  rapidjson::Document   d;
  d.ParseStream<0>(is);

This fixes upstream issue 107 again (see 84f64ba58).
