### PR TITLE
Removal of setjmp()/longjmp()

### DIFF
--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -277,6 +277,9 @@ private:
 				RAPIDJSON_PARSE_ERROR("Name of an object member must be a string", is.Tell());
 
 			ParseString<parseFlags>(is, handler);
+			if (HasParseError())
+				return;
+
 			SkipWhitespace(is);
 
 			if (is.Take() != ':')
@@ -285,6 +288,9 @@ private:
 			SkipWhitespace(is);
 
 			ParseValue<parseFlags>(is, handler);
+			if (HasParseError())
+				return;
+
 			SkipWhitespace(is);
 
 			++memberCount;
@@ -313,6 +319,9 @@ private:
 
 		for (SizeType elementCount = 0;;) {
 			ParseValue<parseFlags>(is, handler);
+			if (HasParseError())
+				return;
+
 			++elementCount;
 			SkipWhitespace(is);
 


### PR DESCRIPTION
Fixes #22 
The removal is simple. An experiments show that the additional checks do not affect the performance much.
