### PR TITLE
Added overloaded functions for default parseFlags

### DIFF
--- a/example/condense/condense.cpp
+++ b/example/condense/condense.cpp
@@ -22,7 +22,7 @@ int main(int, char*[]) {
 	Writer<FileWriteStream> writer(os);
 
 	// JSON reader parse from the input stream and let writer generate the output.
-	if (!reader.Parse<0>(is, writer)) {
+	if (!reader.Parse(is, writer)) {
 		fprintf(stderr, "\nError(%u): %s\n", (unsigned)reader.GetErrorOffset(), reader.GetParseError());
 		return 1;
 	}

--- a/example/simpledom/simpledom.cpp
+++ b/example/simpledom/simpledom.cpp
@@ -12,7 +12,7 @@ int main() {
 	// 1. Parse a JSON string into DOM.
 	const char* json = "{\"project\":\"rapidjson\",\"stars\":10}";
 	Document d;
-	d.Parse<0>(json);
+	d.Parse(json);
 
 	// 2. Modify it by DOM.
 	Value& s = d["stars"];

--- a/example/tutorial/tutorial.cpp
+++ b/example/tutorial/tutorial.cpp
@@ -19,14 +19,14 @@ int main(int, char*[]) {
 
 #if 0
 	// "normal" parsing, decode strings to new buffers. Can use other input stream via ParseStream().
-	if (document.Parse<0>(json).HasParseError())
+	if (document.Parse(json).HasParseError())
 		return 1;
 #else
 	// In-situ parsing, decode strings directly in the source string. Source must be string.
 	{
 		char buffer[sizeof(json)];
 		memcpy(buffer, json, sizeof(json));
-		if (document.ParseInsitu<0>(buffer).HasParseError())
+		if (document.ParseInsitu(buffer).HasParseError())
 			return 1;
 	}
 #endif

--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -818,6 +818,11 @@ public:
 		return ParseStream<parseFlags,Encoding,InputStream>(is);
 	}
 
+	template <typename InputStream>
+	GenericDocument& ParseStream(InputStream& is) {
+		return ParseStream<0, Encoding, InputStream>(is);
+	}
+
 	//! Parse JSON text from a mutable string.
 	/*! \tparam parseFlags Combination of ParseFlag.
 		\param str Mutable zero-terminated string to be parsed.
@@ -834,6 +839,10 @@ public:
 		return ParseInsitu<parseFlags, Encoding>(str);
 	}
 
+	GenericDocument& ParseInsitu(Ch* str) {
+		return ParseInsitu<0, Encoding>(str);
+	}
+
 	//! Parse JSON text from a read-only string.
 	/*! \tparam parseFlags Combination of ParseFlag (must not contain kParseInsituFlag).
 		\param str Read-only zero-terminated string to be parsed.
@@ -848,6 +857,10 @@ public:
 	template <unsigned parseFlags>
 	GenericDocument& Parse(const Ch* str) {
 		return Parse<parseFlags, Encoding>(str);
+	}
+
+	GenericDocument& Parse(const Ch* str) {
+		return Parse<0>(str);
 	}
 
 	//! Whether a parse error was occured in the last parsing.

--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -257,6 +257,11 @@ public:
 		return !HasParseError();
 	}
 
+	template <typename InputStream, typename Handler>
+	bool Parse(InputStream& is, Handler& handler) {
+		return Parse<0>(is, handler);
+	}
+
 	bool HasParseError() const { return parseError_ != 0; }
 	const char* GetParseError() const { return parseError_; }
 	size_t GetErrorOffset() const { return errorOffset_; }

--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ int main() {
     // 1. Parse a JSON string into DOM.
     const char* json = "{\"project\":\"rapidjson\",\"stars\":10}";
     Document d;
-    d.Parse<0>(json);
+    d.Parse(json);
 
     // 2. Modify it by DOM.
     Value& s = d["stars"];

--- a/test/perftest/rapidjsontest.cpp
+++ b/test/perftest/rapidjsontest.cpp
@@ -28,7 +28,7 @@ public:
 		temp_ = (char *)malloc(length_ + 1);
 
 		// Parse as a document
-		EXPECT_FALSE(doc_.Parse<0>(json_).IsNull());
+		EXPECT_FALSE(doc_.Parse(json_).IsNull());
 	}
 
 	virtual void TearDown() {
@@ -66,7 +66,7 @@ TEST_F(RapidJson, SIMD_SUFFIX(ReaderParse_DummyHandler)) {
 		StringStream s(json_);
 		BaseReaderHandler<> h;
 		Reader reader;
-		EXPECT_TRUE(reader.Parse<0>(s, h));
+		EXPECT_TRUE(reader.Parse(s, h));
 	}
 }
 
@@ -88,7 +88,7 @@ TEST_F(RapidJson, SIMD_SUFFIX(DoucmentParseInsitu_MemoryPoolAllocator)) {
 		//MemoryPoolAllocator<> allocator(userBuffer, userBufferSize);
 		//Document doc(&allocator);
 		Document doc;
-		doc.ParseInsitu<0>(temp_);
+		doc.ParseInsitu(temp_);
 		ASSERT_TRUE(doc.IsObject());
 		//if (i == 0) {
 		//	size_t size = doc.GetAllocator().Size();
@@ -110,7 +110,7 @@ TEST_F(RapidJson, SIMD_SUFFIX(DoucmentParse_MemoryPoolAllocator)) {
 		//MemoryPoolAllocator<> allocator(userBuffer, userBufferSize);
 		//Document doc(&allocator);
 		Document doc;
-		doc.Parse<0>(json_);
+		doc.Parse(json_);
 		ASSERT_TRUE(doc.IsObject());
 		//if (i == 0) {
 		//	size_t size = doc.GetAllocator().Size();
@@ -128,7 +128,7 @@ TEST_F(RapidJson, SIMD_SUFFIX(DoucmentParse_CrtAllocator)) {
 	for (size_t i = 0; i < kTrialCount; i++) {
 		memcpy(temp_, json_, length_ + 1);
 		GenericDocument<UTF8<>, CrtAllocator> doc;
-		doc.Parse<0>(temp_);
+		doc.Parse(temp_);
 		ASSERT_TRUE(doc.IsObject());
 	}
 }
@@ -234,7 +234,7 @@ TEST_F(RapidJson, internal_Pow10) {
 TEST_F(RapidJson, SIMD_SUFFIX(Whitespace)) {
 	for (size_t i = 0; i < kTrialCount; i++) {
 		Document doc;
-		ASSERT_TRUE(doc.Parse<0>(whitespace_).IsArray());
+		ASSERT_TRUE(doc.Parse(whitespace_).IsArray());
 	}		
 }
 
@@ -279,7 +279,7 @@ TEST_F(RapidJson, SIMD_SUFFIX(ReaderParse_DummyHandler_FileReadStream)) {
 		FileReadStream s(fp, buffer, sizeof(buffer));
 		BaseReaderHandler<> h;
 		Reader reader;
-		reader.Parse<0>(s, h);
+		reader.Parse(s, h);
 		fclose(fp);
 	}
 }

--- a/test/unittest/documenttest.cpp
+++ b/test/unittest/documenttest.cpp
@@ -8,7 +8,7 @@ using namespace rapidjson;
 TEST(Document, Parse) {
 	Document doc;
 
-	doc.Parse<0>(" { \"hello\" : \"world\", \"t\" : true , \"f\" : false, \"n\": null, \"i\":123, \"pi\": 3.1416, \"a\":[1, 2, 3, 4] } ");
+	doc.Parse(" { \"hello\" : \"world\", \"t\" : true , \"f\" : false, \"n\": null, \"i\":123, \"pi\": 3.1416, \"a\":[1, 2, 3, 4] } ");
 
 	EXPECT_TRUE(doc.IsObject());
 
@@ -59,7 +59,7 @@ struct OutputStringStream : public std::ostringstream {
 
 TEST(Document, AcceptWriter) {
 	Document doc;
-	doc.Parse<0>(" { \"hello\" : \"world\", \"t\" : true , \"f\" : false, \"n\": null, \"i\":123, \"pi\": 3.1416, \"a\":[1, 2, 3, 4] } ");
+	doc.Parse(" { \"hello\" : \"world\", \"t\" : true , \"f\" : false, \"n\": null, \"i\":123, \"pi\": 3.1416, \"a\":[1, 2, 3, 4] } ");
 
 	OutputStringStream os;
 	Writer<OutputStringStream> writer(os);

--- a/test/unittest/jsoncheckertest.cpp
+++ b/test/unittest/jsoncheckertest.cpp
@@ -42,7 +42,7 @@ TEST(JsonChecker, Reader) {
 		}
 
 		GenericDocument<UTF8<>, CrtAllocator> document;	// Use Crt allocator to check exception-safety (no memory leak)
-		if (!document.Parse<0>((const char*)json).HasParseError())
+		if (!document.Parse((const char*)json).HasParseError())
 			FAIL();
 		//printf("%s(%u):%s\n", filename, (unsigned)document.GetErrorOffset(), document.GetParseError());
 		free(json);
@@ -63,7 +63,7 @@ TEST(JsonChecker, Reader) {
 		}
 
 		GenericDocument<UTF8<>, CrtAllocator> document;	// Use Crt allocator to check exception-safety (no memory leak)
-		document.Parse<0>((const char*)json);
+		document.Parse((const char*)json);
 		EXPECT_TRUE(!document.HasParseError());
 		free(json);
 	}


### PR DESCRIPTION
Can write d.Parse(...) instead of d.Parse<0>(...)
Hope to reduce strangeness and confusion for beginner.
