### PR TITLE
GenericReader: simplify local stream copy optimization

### DIFF
--- a/include/rapidjson/rapidjson.h
+++ b/include/rapidjson/rapidjson.h
@@ -209,31 +209,6 @@ struct StreamTraits {
 	enum { copyOptimization = 0 };
 };
 
-template<typename Stream, bool = StreamTraits<Stream>::copyOptimization>
-class StreamLocalCopy;
-
-template<typename Stream>
-class StreamLocalCopy<Stream, 1> {
-public:
-	StreamLocalCopy(Stream& original) : s(original), original_(original) {}
-	~StreamLocalCopy() { original_ = s; }
-
-	Stream s; //!< copy
-private:
-	StreamLocalCopy& operator=(const StreamLocalCopy&) /* = delete */;
-	Stream& original_;
-};
-
-template<typename Stream>
-class StreamLocalCopy<Stream, 0> {
-public:
-	StreamLocalCopy(Stream& original) : s(original) {}
-
-	Stream& s; //!< reference
-private:
-	StreamLocalCopy& operator=(const StreamLocalCopy&) /* = delete */;
-};
-
 //! Put N copies of a character to a stream.
 template<typename Stream, typename Ch>
 inline void PutN(Stream& stream, Ch c, size_t n) {


### PR DESCRIPTION
This pull-request simplifies the changes introduced by #39.  Especially the changes to the algorithms in `GenericReader` are back to plain `s.*` syntax.  This will help me to submit my pending local patches. ;-)

`rapidjson.h`:
- `StreamLocalCopy`: add default argument to copy optimization selector based on `StreamTraits` of `Stream parameter`
- drop `operator->`, `operator*`
- make `Stream` (reference) member public
- drop empty destructor

`reader.h`:
- add local references, initialized from "copy" (reverts algorithmic bodies back to plain 's.xx()')
