### PR TITLE
Travis CI: build/update Doxygen from separate script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,50 +19,14 @@ before_install:
 install: true
 
 before_script:
-  - cd build 
-  - premake4 'gmake'
-  - cd "${TRAVIS_BUILD_DIR}"
+  - pushd build && premake4 'gmake' && popd
 
 script:
   - make -C build/gmake -f test.make
   - make -C build/gmake -f example.make
-  - cd bin
+  - pushd bin
   - ./unittest_${config_suffix}
   - valgrind --leak-check=full --error-exitcode=1 ./unittest_${config_suffix}
   - if [ "$config" = "release64" ]; then ./perftest_${config_suffix}; fi
-
-after_success:
-# Build latest doxygen from source
-#  - if [ "$config" = "release64" -a "$CC" = "clang" ]; then cd /tmp; fi
-#  - if [ "$config" = "release64" -a "$CC" = "clang" ]; then git clone https://github.com/doxygen/doxygen.git; fi
-#  - if [ "$config" = "release64" -a "$CC" = "clang" ]; then cd doxygen; fi
-#  - if [ "$config" = "release64" -a "$CC" = "clang" ]; then ./configure; fi
-#  - if [ "$config" = "release64" -a "$CC" = "clang" ]; then make; fi
-#  - if [ "$config" = "release64" -a "$CC" = "clang" ]; then make distclean; fi
-#  - if [ "$config" = "release64" -a "$CC" = "clang" ]; then git pull; fi
-#  - if [ "$config" = "release64" -a "$CC" = "clang" ]; then ./configure; fi
-#  - if [ "$config" = "release64" -a "$CC" = "clang" ]; then make; fi
-#  - if [ "$config" = "release64" -a "$CC" = "clang" ]; then sudo make install; fi
-
-# Install doxygen binary distribution 
-  - if [ "$config" = "release64" -a "$CC" = "clang" ]; then cd /tmp; fi
-  - if [ "$config" = "release64" -a "$CC" = "clang" ]; then wget http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.7.linux.bin.tar.gz; fi
-  - if [ "$config" = "release64" -a "$CC" = "clang" ]; then tar -xvf doxygen-1.8.7.linux.bin.tar.gz; fi
-  - if [ "$config" = "release64" -a "$CC" = "clang" ]; then sudo install -m 755 doxygen-1.8.7/bin/doxygen /usr/bin; fi
-
-# Run doxygen  
-  - if [ "$config" = "release64" -a "$CC" = "clang" ]; then cd "${TRAVIS_BUILD_DIR}"; fi
-  - if [ "$config" = "release64" -a "$CC" = "clang" ]; then doxygen build/Doxyfile; fi
-
-# Push to Github Pages
-  - if [ "$config" = "release64" -a "$CC" = "clang" ]; then git config --global user.name "${GIT_NAME}"; fi
-  - if [ "$config" = "release64" -a "$CC" = "clang" ]; then git config --global user.email ${GIT_EMAIL}; fi
-  - if [ "$config" = "release64" -a "$CC" = "clang" ]; then mkdir build/doc; fi
-  - if [ "$config" = "release64" -a "$CC" = "clang" ]; then cd build/doc; fi
-  - if [ "$config" = "release64" -a "$CC" = "clang" ]; then git clone https://github.com/miloyip/rapidjson; fi
-  - if [ "$config" = "release64" -a "$CC" = "clang" ]; then cd rapidjson; fi
-  - if [ "$config" = "release64" -a "$CC" = "clang" ]; then git checkout gh-pages; fi
-  - if [ "$config" = "release64" -a "$CC" = "clang" ]; then cp -r ../../../doc/html/* .; fi
-  - if [ "$config" = "release64" -a "$CC" = "clang" ]; then git add --all; fi
-  - if [ "$config" = "release64" -a "$CC" = "clang" ]; then git commit -m "Automatic doxygen build"; fi
-  - if [ "$config" = "release64" -a "$CC" = "clang" ]; then git push https://${GH_TOKEN}@github.com/miloyip/rapidjson gh-pages; fi
+  - popd
+  - ./build/travis-doxygen.sh;

--- a/build/travis-doxygen.sh
+++ b/build/travis-doxygen.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# Update Doxygen documentation after push to 'master'.
+# Author: @pah
+
+set -e
+
+SUDO=sudo
+DOXYGEN_VER=doxygen-1.8.7
+DOXYGEN_TAR=${DOXYGEN_VER}.linux.bin.tar.gz
+DOXYGEN_URL="http://ftp.stack.nl/pub/users/dimitri/${DOXYGEN_TAR}"
+DOXYGEN_BIN="/usr/local/bin/doxygen"
+
+GHPAGES_REPO="miloyip/rapidjson"
+GHPAGES_BASE="https://github.com/${GHPAGES_REPO}"
+# NOTE: not expanded here to hide GH_TOKEN
+GHPAGES_PUSH='https://${GH_TOKEN}@github.com/${GHPAGES_REPO}'
+
+skip() {
+	echo "$@" 1>&2
+	echo "Exiting..." 1>&2
+	exit 0
+}
+
+abort() {
+	echo "Error: $@" 1>&2
+	echo "Exiting..." 1>&2
+	exit 1
+}
+
+# TRAVIS_BUILD_DIR not set, exiting
+[ -d "${TRAVIS_BUILD_DIR-/nonexistent}" ] || \
+	abort '${TRAVIS_BUILD_DIR} not set or nonexistent.'
+
+# check for pull-requests
+[ "${TRAVIS_PULL_REQUEST}" = "false" ] || \
+	skip "Not running Doxygen for pull-requests."
+
+# check for branch name
+[ "${TRAVIS_BRANCH}" = "master" ] || \
+	skip "Running Doxygen only for updates on 'master' branch (current: ${TRAVIS_BRANCH})."
+
+# check for job number
+[ "${TRAVIS_JOB_NUMBER}" = "${TRAVIS_BUILD_NUMBER}.1" ] || \
+	skip "Running Doxygen only on first job of build ${TRAVIS_BUILD_NUMBER} (current: ${TRAVIS_JOB_NUMBER})."
+
+# install doxygen binary distribution
+doxygen_install()
+{
+	wget -O - "${DOXYGEN_URL}" | \
+		tar xz -C ${TMPDIR-/tmp} ${DOXYGEN_VER}/bin/doxygen
+	$SUDO install -m 755 ${TMPDIR-/tmp}/${DOXYGEN_VER}/bin/doxygen \
+		${DOXYGEN_BIN};
+}
+
+doxygen_run()
+{
+	cd "${TRAVIS_BUILD_DIR}";
+	doxygen build/Doxyfile;
+}
+
+gh_pages_prepare()
+{
+	cd "${TRAVIS_BUILD_DIR}/doc";
+	[ ! -d "html" ] || \
+		abort "Doxygen target directory already exists."
+	git clone --single-branch -b gh-pages ${GHPAGES_BASE} html
+	cd html
+	# clean working dir
+	rm -f .git/index
+	git clean -df
+}
+
+gh_pages_commit() {
+	cd "${TRAVIS_BUILD_DIR}/doc/html";
+	git add --all;
+	git commit -m "Automatic doxygen build";
+}
+
+gh_pages_push() {
+	# check for secure variables
+	[ "${TRAVIS_SECURE_ENV_VARS}" = "true" ] || \
+		skip "Secure variables not available, not updating GitHub pages."
+	[ "${GH_TOKEN+set}" = set ] || \
+		skip "GitHub access token not available, not updating GitHub pages."
+
+	cd "${TRAVIS_BUILD_DIR}/doc/html";
+	# push to GitHub without printing GH_TOKEN even in "set -x" mode
+	( echo "git push ${GHPAGES_PUSH} gh-pages" ; set +x; \
+		eval "git push ${GHPAGES_PUSH} gh-pages" )
+}
+
+doxygen_install
+gh_pages_prepare
+doxygen_run
+gh_pages_commit
+gh_pages_push
+


### PR DESCRIPTION
In this patch, a script `build/travis-doxygen.sh` is added to build and push the Doxygen documentation to the GitHub pages at https://miloyip.github.io/rapidjson.

The script exits gracefully, if the build is requested for
- a branch other than `master`
- a pull-request
- a job (i.e. CI configuration) other than "1"

In case the "secure variables" are not available, only the final upload is skipped, in order to allow testing of the script's basic functionality. 

Update `.travis.yml` to call the script.
