### PR TITLE
GenericValue::operator= : fixup assignment operator (again)

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -501,7 +501,8 @@ public:
 		\see GenericStringRef, operator=(T)
 	*/
 	GenericValue& operator=(StringRefType str) {
-		return (*this).operator=<StringRefType>(str);
+		GenericValue s(str);
+		return *this = s;
 	}
 
 	//! Assignment with primitive types.
@@ -519,9 +520,8 @@ public:
 	template <typename T>
 	RAPIDJSON_DISABLEIF_RETURN(internal::IsPointer<T>,GenericValue&)
 	operator=(T value) {
-		this->~GenericValue();
-		new (this) GenericValue(value);
-		return *this;
+		GenericValue v(value);
+		return *this = v;
 	}
 
 	//! Deep-copy assignment from Value


### PR DESCRIPTION
While MSVC doesn't like the explicit `.template operator=<...>` syntax (see 4f40ed6), Clang 3.5 complains about the absence of it:

```
In file included from ../../test/perftest/rapidjsontest.cpp:6:
../../include/rapidjson/document.h:504:18: error: use 'template' keyword to treat 'operator =' as a dependent template name
                return (*this).operator=<StringRefType>(str);
                               ^
                               template
```

Delegate both `operator=(StringRefType)` and `operator=(T)` to `operator=(GenericValue&)`.
