### PR TITLE
Add MemoryBuffer and MemoryStream

### DIFF
--- a/include/rapidjson/memorybuffer.h
+++ b/include/rapidjson/memorybuffer.h
@@ -1,0 +1,55 @@
+#ifndef RAPIDJSON_MEMORYBUFFER_H_
+#define RAPIDJSON_MEMORYBUFFER_H_
+
+#include "rapidjson.h"
+#include "internal/stack.h"
+
+namespace rapidjson {
+
+//! Represents an in-memory output byte stream.
+/*!
+	This class is mainly for being wrapped by EncodedOutputStream or AutoUTFOutputStream.
+
+	It is similar to FileWriteBuffer but the destination is an in-memory buffer instead of a file.
+
+	Differences between MemoryBuffer and StringBuffer:
+	1. StringBuffer has Encoding but MemoryBuffer is only a byte buffer. 
+	2. StringBuffer::GetString() returns a null-terminated string. MemoryBuffer::GetBuffer() returns a buffer without terminator.
+
+	\tparam Allocator type for allocating memory buffer.
+	\note implements Stream concept
+*/
+template <typename Allocator = CrtAllocator>
+struct GenericMemoryBuffer {
+	typedef char Ch; // byte
+
+	GenericMemoryBuffer(Allocator* allocator = 0, size_t capacity = kDefaultCapacity) : stack_(allocator, capacity) {}
+
+	void Put(Ch c) { *stack_.template Push<Ch>() = c; }
+	void Flush() {}
+
+	void Clear() { stack_.Clear(); }
+	Ch* Push(size_t count) { return stack_.template Push<Ch>(count); }
+	void Pop(size_t count) { stack_.template Pop<Ch>(count); }
+
+	const Ch* GetBuffer() const {
+		return stack_.template Bottom<Ch>();
+	}
+
+	size_t GetSize() const { return stack_.GetSize(); }
+
+	static const size_t kDefaultCapacity = 256;
+	mutable internal::Stack<Allocator> stack_;
+};
+
+typedef GenericMemoryBuffer<> MemoryBuffer;
+
+//! Implement specialized version of PutN() with memset() for better performance.
+template<>
+inline void PutN(MemoryBuffer& memoryBuffer, char c, size_t n) {
+	memset(memoryBuffer.stack_.Push<char>(n), c, n * sizeof(c));
+}
+
+} // namespace rapidjson
+
+#endif // RAPIDJSON_MEMORYBUFFER_H_

--- a/include/rapidjson/memorystream.h
+++ b/include/rapidjson/memorystream.h
@@ -1,0 +1,47 @@
+#ifndef RAPIDJSON_MEMORYSTREAM_H_
+#define RAPIDJSON_MEMORYSTREAM_H_
+
+#include "rapidjson.h"
+
+namespace rapidjson {
+
+//! Represents an in-memory input byte stream.
+/*!
+	This class is mainly for being wrapped by EncodedInputStream or AutoUTFInputStream.
+
+	It is similar to FileReadBuffer but the source is an in-memory buffer instead of a file.
+
+	Differences between MemoryStream and StringStream:
+	1. StringStream has encoding but MemoryStream is a byte stream.
+	2. MemoryStream needs size of the source buffer and the buffer don't need to be null terminated. StringStream assume null-terminated string as source.
+	3. MemoryStream supports Peek4() for encoding detection. StringStream is specified with an encoding so it should not have Peek4().
+	\note implements Stream concept
+*/
+struct MemoryStream {
+	typedef char Ch; // byte
+
+	MemoryStream(const Ch *src, size_t size) : src_(src), begin_(src), end_(src + size), size_(size) {}
+
+	Ch Peek() const { return *src_; }
+	Ch Take() { return (src_ == end_) ? '\0' : *src_++; }
+	size_t Tell() const { return static_cast<size_t>(src_ - begin_); }
+
+	Ch* PutBegin() { RAPIDJSON_ASSERT(false); return 0; }
+	void Put(Ch) { RAPIDJSON_ASSERT(false); }
+	void Flush() { RAPIDJSON_ASSERT(false); }
+	size_t PutEnd(Ch*) { RAPIDJSON_ASSERT(false); return 0; }
+
+	// For encoding detection only.
+	const Ch* Peek4() const {
+		return Tell() + 4 <= size_ ? src_ : 0;
+	}
+
+	const Ch* src_;		//!< Current read position.
+	const Ch* begin_;	//!< Original head of the string.
+	const Ch* end_;		//!< End of stream.
+	size_t size_;		//!< Size of the stream.
+};
+
+} // namespace rapidjson
+
+#endif // RAPIDJSON_MEMORYBUFFER_H_


### PR DESCRIPTION
Fix #79 as requested by @M1chae1 
I proposed to add two classes `MemoryStream` and `MemoryBuffer` for representing input and output byte streams in memory (like in-memory file).
There are some differences with directly using StringStream/StringBuffer, as listed in the API documentation.
I hope these classes can be better to suit the purposes.
