### PR TITLE
premake.lua: relax warnings for GTest and perftest (fixes #86)

### DIFF
--- a/build/premake4.lua
+++ b/build/premake4.lua
@@ -64,7 +64,7 @@ solution "test"
 		defines { "_CRT_SECURE_NO_WARNINGS" }
 		
 	configuration "gmake"
-		buildoptions "-msse4.2 -Werror -Wall -Wextra"
+		buildoptions "-msse4.2 -Wall -Wextra"
 
 	project "gtest"
 		kind "StaticLib"
@@ -87,7 +87,7 @@ solution "test"
 		kind "ConsoleApp"
 		
 		if _ACTION == "gmake" then
-			buildoptions "-Weffc++ -Wswitch-default"
+			buildoptions "-Werror -Weffc++ -Wswitch-default"
 		end
 
 		files { 


### PR DESCRIPTION
For the `test` solution, the `gtest` and `perftest` projects contain third-party code.  Relax the warning settings for `gmake` for these projects to avoid build failures due to third-party code (fixes #86).
