### PR TITLE
Fix sign-comparison warning/error on 32-bit platforms

### DIFF
--- a/test/unittest/valuetest.cpp
+++ b/test/unittest/valuetest.cpp
@@ -838,7 +838,7 @@ TEST(Value, Object) {
     itr = x.EraseMember(x.MemberBegin());
     EXPECT_FALSE(x.HasMember(keys[0]));
     EXPECT_EQ(x.MemberBegin(), itr);
-    EXPECT_EQ(9u, x.MemberEnd() - x.MemberBegin());
+    EXPECT_EQ(9, x.MemberEnd() - x.MemberBegin());
     for (; itr != x.MemberEnd(); ++itr) {
         int i = (itr - x.MemberBegin()) + 1;
         EXPECT_STREQ(itr->name.GetString(), keys[i]);
@@ -849,7 +849,7 @@ TEST(Value, Object) {
     itr = x.EraseMember(x.MemberEnd() - 1);
     EXPECT_FALSE(x.HasMember(keys[9]));
     EXPECT_EQ(x.MemberEnd(), itr);
-    EXPECT_EQ(8u, x.MemberEnd() - x.MemberBegin());
+    EXPECT_EQ(8, x.MemberEnd() - x.MemberBegin());
     for (; itr != x.MemberEnd(); ++itr) {
         int i = (itr - x.MemberBegin()) + 1;
         EXPECT_STREQ(itr->name.GetString(), keys[i]);
@@ -860,7 +860,7 @@ TEST(Value, Object) {
     itr = x.EraseMember(x.MemberBegin() + 4);
     EXPECT_FALSE(x.HasMember(keys[5]));
     EXPECT_EQ(x.MemberBegin() + 4, itr);
-    EXPECT_EQ(7u, x.MemberEnd() - x.MemberBegin());
+    EXPECT_EQ(7, x.MemberEnd() - x.MemberBegin());
     for (; itr != x.MemberEnd(); ++itr) {
         int i = (itr - x.MemberBegin());
         i += (i<4) ? 1 : 2;


### PR DESCRIPTION
On 32-bit platforms, Clang errors out with a sign-comparison error for the `MemberIterator` difference checks:

```
In file included from ../../test/unittest/valuetest.cpp:1:
In file included from ../../test/unittest/unittest.h:23:
../../thirdparty/gtest/include/gtest/gtest.h:1316:16: error: comparison of integers of different signs:
      'const unsigned int' and 'const int' [-Werror,-Wsign-compare]
  if (expected == actual) {
      ~~~~~~~~ ^  ~~~~~~
../../thirdparty/gtest/include/gtest/gtest.h:1352:12: note: in instantiation of function template
      specialization 'testing::internal::CmpHelperEQ<unsigned int, int>' requested here
    return CmpHelperEQ(expected_expression, actual_expression, expected,
           ^
../../test/unittest/valuetest.cpp:821:2: note: in instantiation of function template specialization
      'testing::internal::EqHelper<false>::Compare<unsigned int, int>' requested here
        EXPECT_EQ(9u, x.MemberEnd() - x.MemberBegin());
```

On 64-bit platforms, this is hidden by the C++ integer promotion rules (`unsigned` -> `ptrdiff_t`).

As side note: Do we want to add an `ObjectSize()` function to query the number of members of an object?
