### PR TITLE
.travis.yml: enable 32-bit builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ env:
 before_install:
   - sudo add-apt-repository -y ppa:codegear/release
   - sudo apt-get update -qq
-  - sudo apt-get install -qq premake4 valgrind g++-multilib libc6-dbg:i386
+  - sudo apt-get install -qq premake4 valgrind
+  - if [ "$BITS" = 32 ]; then sudo apt-get install -qq g++-multilib libc6-dbg:i386; fi
 
 install: true
 


### PR DESCRIPTION
As Ubuntu supports running 32-bit executables on 64-bit installations based on its [multiarch](https://help.ubuntu.com/community/MultiArch) setup, we can enable the tests on 32-bit configurations as well.

Currently, valgrind fails for 32-bit executables on the 64-bit host. This requires some more investigation.
