### PR TITLE
Add Doxygen documentation for configuration macros and error handling

### DIFF
--- a/build/Doxyfile
+++ b/build/Doxyfile
@@ -764,7 +764,8 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ./include/ \
+INPUT                  = ./include/rapidjson/rapidjson.h \
+                         ./include/ \
                          ./readme.md \
                          ./doc/features.md \
                          ./doc/tutorial.md \

--- a/include/rapidjson/error/en.h
+++ b/include/rapidjson/error/en.h
@@ -27,6 +27,7 @@ namespace rapidjson {
 
 //! Maps error code of parsing into error message.
 /*!
+    \ingroup RAPIDJSON_ERRORS
     \param parseErrorCode Error code obtained in parsing.
     \return the error message.
     \note User can make a copy of this function for localization.

--- a/include/rapidjson/error/error.h
+++ b/include/rapidjson/error/error.h
@@ -21,12 +21,17 @@
 #ifndef RAPIDJSON_ERROR_ERROR_H__
 #define RAPIDJSON_ERROR_ERROR_H__
 
+/*! \file error.h */
+
+/*! \defgroup RAPIDJSON_ERRORS RapidJSON error handling */
+
 ///////////////////////////////////////////////////////////////////////////////
 // RAPIDJSON_ERROR_CHARTYPE
 
 //! Character type of error messages.
-/*! The default charater type is char.
-    On Windows, user can define this macro as TCHAR for supporting both
+/*! \ingroup RAPIDJSON_ERRORS
+    The default character type is \c char.
+    On Windows, user can define this macro as \c TCHAR for supporting both
     unicode/non-unicode settings.
 */
 #ifndef RAPIDJSON_ERROR_CHARTYPE
@@ -36,9 +41,10 @@
 ///////////////////////////////////////////////////////////////////////////////
 // RAPIDJSON_ERROR_STRING
 
-//! Macro for converting string literial to RAPIDJSON_ERROR_CHARTYPE[].
-/*! By default this conversion macro does nothing.
-    On Windows, user can define this macro as _T(x) for supporting both 
+//! Macro for converting string literial to \ref RAPIDJSON_ERROR_CHARTYPE[].
+/*! \ingroup RAPIDJSON_ERRORS
+    By default this conversion macro does nothing.
+    On Windows, user can define this macro as \c _T(x) for supporting both
     unicode/non-unicode settings.
 */
 #ifndef RAPIDJSON_ERROR_STRING
@@ -51,7 +57,8 @@ namespace rapidjson {
 // ParseErrorCode
 
 //! Error code of parsing.
-/*! \see GenericReader::Parse, GenericReader::GetParseErrorCode
+/*! \ingroup RAPIDJSON_ERRORS
+    \see GenericReader::Parse, GenericReader::GetParseErrorCode
 */
 enum ParseErrorCode {
     kParseErrorNone = 0,                        //!< No error.
@@ -83,6 +90,7 @@ enum ParseErrorCode {
 
 //! Result of parsing (wraps ParseErrorCode)
 /*!
+    \ingroup RAPIDJSON_ERRORS
     \code
         Document doc;
         ParseResult ok = doc.Parse("[42]");
@@ -126,15 +134,15 @@ private:
 };
 
 //! Function pointer type of GetParseError().
-/*! This is the prototype for GetParseError_X(), where X is a locale.
-    User can dynamically change locale in runtime, e.g.:
+/*! \ingroup RAPIDJSON_ERRORS
 
+    This is the prototype for \c GetParseError_X(), where \c X is a locale.
+    User can dynamically change locale in runtime, e.g.:
 \code
     GetParseErrorFunc GetParseError = GetParseError_En; // or whatever
     const RAPIDJSON_ERROR_CHARTYPE* s = GetParseError(document.GetParseErrorCode());
 \endcode
 */
-
 typedef const RAPIDJSON_ERROR_CHARTYPE* (*GetParseErrorFunc)(ParseErrorCode);
 
 } // namespace rapidjson

--- a/include/rapidjson/rapidjson.h
+++ b/include/rapidjson/rapidjson.h
@@ -243,6 +243,9 @@ typedef unsigned SizeType;
 /*! \ingroup RAPIDJSON_CONFIG
     By default, rapidjson uses C \c assert() for internal assertions.
     User can override it by defining RAPIDJSON_ASSERT(x) macro.
+
+    \note Parsing errors are handled and can be customized by the
+          \ref RAPIDJSON_ERRORS APIs.
 */
 #ifndef RAPIDJSON_ASSERT
 #include <cassert>
@@ -274,7 +277,7 @@ template<int x> struct StaticAssertTest {};
 //!@endcond
 
 /*! \def RAPIDJSON_STATIC_ASSERT
-    \brief (internal) macro to check for conditions at compile-time
+    \brief (Internal) macro to check for conditions at compile-time
     \param x compile-time condition
     \hideinitializer
  */


### PR DESCRIPTION
This pull-request adds two groups of Doxygen documentation, most importantly covering the different preprocessor macros to customize the library use.

The only code change is the addition of a protected `SetParseError` function to hide the name of the `parseResult_` member from the user (through the documentation of `RAPIDJSON_PARSE_ERROR_NORETURN`.
