### PR TITLE
Three new APIs are added for JSON object type.

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -748,7 +748,7 @@ public:
     SizeType MemberCount() const { RAPIDJSON_ASSERT(IsObject()); return data_.o.size; }
 
     //! Check whether the object is empty.
-    bool MemberEmpty() const { RAPIDJSON_ASSERT(IsObject()); return data_.o.size == 0; }
+    bool ObjectEmpty() const { RAPIDJSON_ASSERT(IsObject()); return data_.o.size == 0; }
 
     //! Get the value associated with the name.
     /*!

--- a/test/unittest/valuetest.cpp
+++ b/test/unittest/valuetest.cpp
@@ -763,16 +763,16 @@ TEST(Value, Object) {
 
     EXPECT_EQ(kObjectType, x.GetType());
     EXPECT_TRUE(x.IsObject());
-    EXPECT_TRUE(x.MemberEmpty());
+    EXPECT_TRUE(x.ObjectEmpty());
     EXPECT_EQ(0u, x.MemberCount());
     EXPECT_EQ(kObjectType, y.GetType());
     EXPECT_TRUE(y.IsObject());
-    EXPECT_TRUE(y.MemberEmpty());
+    EXPECT_TRUE(y.ObjectEmpty());
     EXPECT_EQ(0u, y.MemberCount());
 
     // AddMember()
     x.AddMember("A", "Apple", allocator);
-    EXPECT_FALSE(x.MemberEmpty());
+    EXPECT_FALSE(x.ObjectEmpty());
     EXPECT_EQ(1u, x.MemberCount());
 
     Value value("Banana", 6);
@@ -965,7 +965,7 @@ TEST(Value, Object) {
 
     // RemoveAllMembers()
     x.RemoveAllMembers();
-    EXPECT_TRUE(x.MemberEmpty());
+    EXPECT_TRUE(x.ObjectEmpty());
     EXPECT_EQ(0u, x.MemberCount());
 
     // SetObject()


### PR DESCRIPTION
With quite some discussions on naming of the APIs, finally adds 3 new APIs:
- `bool ObjectEmpty()`
- `SizeType MemberCount()`
- `RemoveAllMembers()`

APIs similar to `vector::capacity()` and `vector::reserve()` are not added for member, because [some possible implementations of associative array](https://github.com/miloyip/rapidjson/issues/102) may be considered in the future and these APIs may not be suitable for those situations.

Fixes #116 
