### PR TITLE
GenericValue: reduce growth factor for array/object reallocations

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -885,7 +885,7 @@ public:
             }
             else {
                 SizeType oldCapacity = o.capacity;
-                o.capacity += (oldCapacity >> 1); // grow by factor 1.5
+                o.capacity += (oldCapacity + 1) / 2; // grow by factor 1.5
                 o.members = reinterpret_cast<Member*>(allocator.Realloc(o.members, oldCapacity * sizeof(Member), o.capacity * sizeof(Member)));
             }
         }
@@ -1130,7 +1130,7 @@ int z = a[0u].GetInt();             // This works too.
     GenericValue& PushBack(GenericValue& value, Allocator& allocator) {
         RAPIDJSON_ASSERT(IsArray());
         if (data_.a.size >= data_.a.capacity)
-            Reserve(data_.a.capacity == 0 ? kDefaultArrayCapacity : (data_.a.capacity + (data_.a.capacity >> 1)), allocator);
+            Reserve(data_.a.capacity == 0 ? kDefaultArrayCapacity : (data_.a.capacity + (data_.a.capacity + 1) / 2), allocator);
         data_.a.elements[data_.a.size++].RawAssign(value);
         return *this;
     }


### PR DESCRIPTION
As mentioned by @kosta-github in [#128](http://git.io/0gkYSg), the currently used growth factor of 2 is suboptimal for memory performance.  An extensive discussion on the topic can be found in the [FBVector](https://github.com/facebook/folly/blob/master/folly/docs/FBVector.md) documentation.

This pull-request reduces the array/object capacity growth factor to 1.5, which many C++ implementations have chosen to use.  In order to avoid floating-point arithmetic for computing the new capacity, I did not
add any customization parameter for the factor and used a shift+add instead.
