### PR TITLE
Alternative compilation fix for Solaris

### DIFF
--- a/include/rapidjson/allocators.h
+++ b/include/rapidjson/allocators.h
@@ -68,9 +68,9 @@ concept Allocator {
 class CrtAllocator {
 public:
     static const bool kNeedFree = true;
-    void* Malloc(size_t size) { return malloc(size); }
-    void* Realloc(void* originalPtr, size_t originalSize, size_t newSize) { (void)originalSize; return realloc(originalPtr, newSize); }
-    static void Free(void *ptr) { free(ptr); }
+    void* Malloc(size_t size) { return std::malloc(size); }
+    void* Realloc(void* originalPtr, size_t originalSize, size_t newSize) { (void)originalSize; return std::realloc(originalPtr, newSize); }
+    static void Free(void *ptr) { std::free(ptr); }
 };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -200,7 +200,7 @@ public:
         // Realloc process: allocate and copy memory, do not free original buffer.
         void* newBuffer = Malloc(newSize);
         RAPIDJSON_ASSERT(newBuffer != 0);   // Do not handle out-of-memory explicitly.
-        return memcpy(newBuffer, originalPtr, originalSize);
+        return std::memcpy(newBuffer, originalPtr, originalSize);
     }
 
     //! Frees a memory block (concept Allocator)

--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -1097,7 +1097,7 @@ public:
         MemberIterator pos = MemberBegin() + (first - MemberBegin());
         for (MemberIterator itr = pos; itr != last; ++itr)
             itr->~Member();
-        memmove(&*pos, &*last, (MemberEnd() - last) * sizeof(Member));
+        std::memmove(&*pos, &*last, (MemberEnd() - last) * sizeof(Member));
         data_.o.size -= (last - first);
         return pos;
     }
@@ -1277,7 +1277,7 @@ int z = a[0u].GetInt();             // This works too.
         ValueIterator pos = Begin() + (first - Begin());
         for (ValueIterator itr = pos; itr != last; ++itr)
             itr->~GenericValue();       
-        memmove(pos, last, (End() - last) * sizeof(GenericValue));
+        std::memmove(pos, last, (End() - last) * sizeof(GenericValue));
         data_.a.size -= (last - first);
         return pos;
     }
@@ -1527,7 +1527,7 @@ private:
     void SetArrayRaw(GenericValue* values, SizeType count, Allocator& allocator) {
         flags_ = kArrayFlag;
         data_.a.elements = (GenericValue*)allocator.Malloc(count * sizeof(GenericValue));
-        memcpy(data_.a.elements, values, count * sizeof(GenericValue));
+        std::memcpy(data_.a.elements, values, count * sizeof(GenericValue));
         data_.a.size = data_.a.capacity = count;
     }
 
@@ -1535,7 +1535,7 @@ private:
     void SetObjectRaw(Member* members, SizeType count, Allocator& allocator) {
         flags_ = kObjectFlag;
         data_.o.members = (Member*)allocator.Malloc(count * sizeof(Member));
-        memcpy(data_.o.members, members, count * sizeof(Member));
+        std::memcpy(data_.o.members, members, count * sizeof(Member));
         data_.o.size = data_.o.capacity = count;
     }
 
@@ -1559,7 +1559,7 @@ private:
             str = (Ch *)allocator.Malloc((s.length + 1) * sizeof(Ch));
             data_.s.str = str;
         }
-        memcpy(str, s, s.length * sizeof(Ch));
+        std::memcpy(str, s, s.length * sizeof(Ch));
         str[s.length] = '\0';
     }
 
@@ -1583,7 +1583,7 @@ private:
         const Ch* const str2 = rhs.GetString();
         if(str1 == str2) { return true; } // fast path for constant string
 
-        return (memcmp(str1, str2, sizeof(Ch) * len1) == 0);
+        return (std::memcmp(str1, str2, sizeof(Ch) * len1) == 0);
     }
 
     Data data_;

--- a/include/rapidjson/filewritestream.h
+++ b/include/rapidjson/filewritestream.h
@@ -48,7 +48,7 @@ public:
     void PutN(char c, size_t n) {
         size_t avail = static_cast<size_t>(bufferEnd_ - current_);
         while (n > avail) {
-            memset(current_, c, avail);
+            std::memset(current_, c, avail);
             current_ += avail;
             Flush();
             n -= avail;
@@ -56,7 +56,7 @@ public:
         }
 
         if (n > 0) {
-            memset(current_, c, n);
+            std::memset(current_, c, n);
             current_ += n;
         }
     }

--- a/include/rapidjson/internal/dtoa.h
+++ b/include/rapidjson/internal/dtoa.h
@@ -362,14 +362,14 @@ inline char* Prettify(char* buffer, int length, int k) {
     }
     else if (0 < kk && kk <= 21) {
         // 1234e-2 -> 12.34
-        memmove(&buffer[kk + 1], &buffer[kk], length - kk);
+        std::memmove(&buffer[kk + 1], &buffer[kk], length - kk);
         buffer[kk] = '.';
         return &buffer[length + 1];
     }
     else if (-6 < kk && kk <= 0) {
         // 1234e-6 -> 0.001234
         const int offset = 2 - kk;
-        memmove(&buffer[offset], &buffer[0], length);
+        std::memmove(&buffer[offset], &buffer[0], length);
         buffer[0] = '0';
         buffer[1] = '.';
         for (int i = 2; i < offset; i++)
@@ -383,7 +383,7 @@ inline char* Prettify(char* buffer, int length, int k) {
     }
     else {
         // 1234e30 -> 1.234e33
-        memmove(&buffer[2], &buffer[1], length - 1);
+        std::memmove(&buffer[2], &buffer[1], length - 1);
         buffer[1] = '.';
         buffer[length + 1] = 'e';
         return WriteExponent(kk - 1, &buffer[0 + length + 2]);

--- a/include/rapidjson/memorybuffer.h
+++ b/include/rapidjson/memorybuffer.h
@@ -68,7 +68,7 @@ typedef GenericMemoryBuffer<> MemoryBuffer;
 //! Implement specialized version of PutN() with memset() for better performance.
 template<>
 inline void PutN(MemoryBuffer& memoryBuffer, char c, size_t n) {
-    memset(memoryBuffer.stack_.Push<char>(n), c, n * sizeof(c));
+    std::memset(memoryBuffer.stack_.Push<char>(n), c, n * sizeof(c));
 }
 
 } // namespace rapidjson

--- a/include/rapidjson/rapidjson.h
+++ b/include/rapidjson/rapidjson.h
@@ -46,7 +46,7 @@
  */
 
 #include <cstdlib>  // malloc(), realloc(), free(), size_t
-#include <cstring>  // memcpy()
+#include <cstring>  // memset(), memcpy(), memmove(), memcmp()
 
 ///////////////////////////////////////////////////////////////////////////////
 // RAPIDJSON_NO_INT64DEFINE

--- a/include/rapidjson/stringbuffer.h
+++ b/include/rapidjson/stringbuffer.h
@@ -71,7 +71,7 @@ typedef GenericStringBuffer<UTF8<> > StringBuffer;
 //! Implement specialized version of PutN() with memset() for better performance.
 template<>
 inline void PutN(GenericStringBuffer<UTF8<> >& stream, char c, size_t n) {
-    memset(stream.stack_.Push<char>(n), c, n * sizeof(c));
+    std::memset(stream.stack_.Push<char>(n), c, n * sizeof(c));
 }
 
 } // namespace rapidjson


### PR DESCRIPTION
Instead of explicitly adding special cases for the Solaris Studio compiler, as proposed in #146, this pull-request addresses the issue from a different angle.

First, the packing `#pragma` is dropped altogether from the `GenericValue` struct.  Even if the compiler decides to add additional padding, this would help for the small-string optimisation and the compiler might have good reasons for that anyhow (e.g. better performance due to better alignment).

Secondly, Sun Studio is known to have quite strict C++ header implementations for the C standard functions (`<cstdlib>`, `cstring>`).  On this implementation, the functions are not automatically exported to the global namespace.  Use explicit `std::` namespace qualifiers instead of including the plain C headers.
