### PR TITLE
Use more stdint.h types and document disabling stdint.h

### DIFF
--- a/doc/sax.md
+++ b/doc/sax.md
@@ -62,8 +62,8 @@ using namespace std;
 struct MyHandler {
     bool Null() { cout << "Null()" << endl; return true; }
     bool Bool(bool b) { cout << "Bool(" << boolalpha << b << ")" << endl; return true; }
-    bool Int(int i) { cout << "Int(" << i << ")" << endl; return true; }
-    bool Uint(unsigned u) { cout << "Uint(" << u << ")" << endl; return true; }
+    bool Int(int32_t i) { cout << "Int(" << i << ")" << endl; return true; }
+    bool Uint(uint32_t u) { cout << "Uint(" << u << ")" << endl; return true; }
     bool Int64(int64_t i) { cout << "Int64(" << i << ")" << endl; return true; }
     bool Uint64(uint64_t u) { cout << "Uint64(" << u << ")" << endl; return true; }
     bool Double(double d) { cout << "Double(" << d << ")" << endl; return true; }
@@ -101,8 +101,8 @@ As the previous example showed, user needs to implement a handler, which consume
 class Handler {
     bool Null();
     bool Bool(bool b);
-    bool Int(int i);
-    bool Uint(unsigned i);
+    bool Int(int32_t i);
+    bool Uint(uint32_t i);
     bool Int64(int64_t i);
     bool Uint64(uint64_t i);
     bool Double(double d);
@@ -119,7 +119,7 @@ class Handler {
 
 `Bool(bool)` is called when the `Reader` encounters a JSON true or false value.
 
-When the `Reader` encounters a JSON number, it chooses a suitable C++ type mapping. And then it calls *one* function out of `Int(int)`, `Uint(unsigned)`, `Int64(int64_t)`, `Uint64(uint64_t)` and `Double(double)`.
+When the `Reader` encounters a JSON number, it chooses a suitable C++ type mapping. And then it calls *one* function out of `Int(int32_t)`, `Uint(uint32_t)`, `Int64(int64_t)`, `Uint64(uint64_t)` and `Double(double)`.
 
 `String(const char* str, SizeType length, bool copy)` is called when the `Reader` encounters a string. The first parameter is pointer to the string. The second parameter is the length of the string (excluding the null terminator). Note that RapidJSON supports null character `'\0'` inside a string. If such situation happens, `strlen(str) < length`. The last `copy` indicates whether the handler needs to make a copy of the string. For normal parsing, `copy = true`. Only when *insitu* parsing is used, `copy = false`. And beware that, the character type depends on the target encoding, which will be explained later.
 
@@ -413,8 +413,8 @@ struct CapitalizeFilter {
 
     bool Null() { return out_.Null(); }
     bool Bool(bool b) { return out_.Bool(b); }
-    bool Int(int i) { return out_.Int(i); }
-    bool Uint(unsigned u) { return out_.Uint(u); }
+    bool Int(int32_t i) { return out_.Int(i); }
+    bool Uint(uint32_t u) { return out_.Uint(u); }
     bool Int64(int64_t i) { return out_.Int64(i); }
     bool Uint64(uint64_t u) { return out_.Uint64(u); }
     bool Double(double d) { return out_.Double(d); }

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -85,7 +85,7 @@ assert(document["i"].IsNumber());
 // In this case, IsUint()/IsInt64()/IsUInt64() also return true.
 assert(document["i"].IsInt());          
 printf("i = %d\n", document["i"].GetInt());
-// Alternative (int)document["i"]
+// Alternative (int32_t)document["i"]
 
 assert(document["pi"].IsNumber());
 assert(document["pi"].IsDouble());
@@ -181,8 +181,8 @@ When the DOM parses a Number, it stores it as either one of the following type:
 
 Type       | Description
 -----------|---------------------------------------
-`unsigned` | 32-bit unsigned integer
-`int`      | 32-bit signed integer
+`uint32_t` | 32-bit unsigned integer
+`int32_t`  | 32-bit signed integer
 `uint64_t` | 64-bit unsigned integer
 `int64_t`  | 64-bit signed integer
 `double`   | 64-bit double precision floating point
@@ -192,15 +192,15 @@ When querying a number, you can check whether the number can be obtained as targ
 Checking          | Obtaining
 ------------------|---------------------
 `bool IsNumber()` | N/A
-`bool IsUint()`   | `unsigned GetUint()`
-`bool IsInt()`    | `int GetInt()`
+`bool IsUint()`   | `uint32_t GetUint()`
+`bool IsInt()`    | `int32_t GetInt()`
 `bool IsUint64()` | `uint64_t GetUint()`
 `bool IsInt64()`  | `int64_t GetInt64()`
 `bool IsDouble()` | `double GetDouble()`
 
 Note that, an integer value may be obtained in various ways without conversion. For example, A value `x` containing 123 will make `x.IsInt() == x.IsUint() == x.IsInt64() == x.IsUint64() == true`. But a value `y` containing -3000000000 will only makes `x.IsInt64() == true`.
 
-When obtaining the numeric values, `GetDouble()` will convert internal integer representation to a `double`. Note that, `int` and `uint` can be safely convert to `double`, but `int64_t` and `uint64_t` may lose precision (since mantissa of `double` is only 52-bits).
+When obtaining the numeric values, `GetDouble()` will convert internal integer representation to a `double`. Note that, `int32_t` and `uint32_t` can be safely convert to `double`, but `int64_t` and `uint64_t` may lose precision (since mantissa of `double` is only 52-bits).
 
 ## Query String {#QueryString}
 
@@ -263,8 +263,8 @@ There are also overloaded constructors for several types:
 
 ~~~~~~~~~~cpp
 Value b(true);    // calls Value(bool)
-Value i(-123);    // calls Value(int)
-Value u(123u);    // calls Value(unsigned)
+Value i(-123);    // calls Value(int32_t)
+Value u(123u);    // calls Value(uint32_t)
 Value d(1.5);     // calls Value(double)
 ~~~~~~~~~~
 

--- a/example/capitalize/capitalize.cpp
+++ b/example/capitalize/capitalize.cpp
@@ -19,8 +19,8 @@ struct CapitalizeFilter {
 
     bool Null() { return out_.Null(); }
     bool Bool(bool b) { return out_.Bool(b); }
-    bool Int(int i) { return out_.Int(i); }
-    bool Uint(unsigned u) { return out_.Uint(u); }
+    bool Int(int32_t i) { return out_.Int(i); }
+    bool Uint(uint32_t u) { return out_.Uint(u); }
     bool Int64(int64_t i) { return out_.Int64(i); }
     bool Uint64(uint64_t u) { return out_.Uint64(u); }
     bool Double(double d) { return out_.Double(d); }

--- a/example/simplereader/simplereader.cpp
+++ b/example/simplereader/simplereader.cpp
@@ -7,8 +7,8 @@ using namespace std;
 struct MyHandler {
     bool Null() { cout << "Null()" << endl; return true; }
     bool Bool(bool b) { cout << "Bool(" << boolalpha << b << ")" << endl; return true; }
-    bool Int(int i) { cout << "Int(" << i << ")" << endl; return true; }
-    bool Uint(unsigned u) { cout << "Uint(" << u << ")" << endl; return true; }
+    bool Int(int32_t i) { cout << "Int(" << i << ")" << endl; return true; }
+    bool Uint(uint32_t u) { cout << "Uint(" << u << ")" << endl; return true; }
     bool Int64(int64_t i) { cout << "Int64(" << i << ")" << endl; return true; }
     bool Uint64(uint64_t u) { cout << "Uint64(" << u << ")" << endl; return true; }
     bool Double(double d) { cout << "Double(" << d << ")" << endl; return true; }

--- a/example/tutorial/tutorial.cpp
+++ b/example/tutorial/tutorial.cpp
@@ -60,7 +60,7 @@ int main(int, char*[]) {
 
     assert(document["i"].IsNumber());   // Number is a JSON type, but C++ needs more specific type.
     assert(document["i"].IsInt());      // In this case, IsUint()/IsInt64()/IsUInt64() also return true.
-    printf("i = %d\n", document["i"].GetInt()); // Alternative (int)document["i"]
+    printf("i = %d\n", document["i"].GetInt()); // Alternative (int32_t)document["i"]
 
     assert(document["pi"].IsNumber());
     assert(document["pi"].IsDouble());
@@ -73,9 +73,9 @@ int main(int, char*[]) {
             printf("a[%d] = %d\n", i, a[i].GetInt());
         
         // Note:
-        //int x = a[0].GetInt();                    // Error: operator[ is ambiguous, as 0 also mean a null pointer of const char* type.
-        int y = a[SizeType(0)].GetInt();            // Cast to SizeType will work.
-        int z = a[0u].GetInt();                     // This works too.
+        //int32_t x = a[0].GetInt();                // Error: operator[ is ambiguous, as 0 also mean a null pointer of const char* type.
+        int32_t y = a[SizeType(0)].GetInt();        // Cast to SizeType will work.
+        int32_t z = a[0u].GetInt();                 // This works too.
         (void)y;
         (void)z;
 
@@ -100,7 +100,7 @@ int main(int, char*[]) {
         for (uint64_t j = 1; j <= 20; j++)
             f20 *= j;
         document["i"] = f20;    // Alternate form: document["i"].SetUint64(f20)
-        assert(!document["i"].IsInt()); // No longer can be cast as int or uint.
+        assert(!document["i"].IsInt()); // No longer can be cast as int32_t or uint32_t.
     }
 
     // Adding values to array.

--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -487,16 +487,16 @@ public:
             RAPIDJSON_STATIC_ASSERT((internal::IsSame<bool,T>::Value));
     }
 
-    //! Constructor for int value.
-    explicit GenericValue(int i) RAPIDJSON_NOEXCEPT : data_(), flags_(kNumberIntFlag) {
-        data_.n.i64 = i;
+    //! Constructor for int32_t value.
+    explicit GenericValue(int32_t i) RAPIDJSON_NOEXCEPT : data_(), flags_(kNumberIntFlag) {
+        data_.n.i64 = static_cast<int64_t>(i);
         if (i >= 0)
             flags_ |= kUintFlag | kUint64Flag;
     }
 
-    //! Constructor for unsigned value.
-    explicit GenericValue(unsigned u) RAPIDJSON_NOEXCEPT : data_(), flags_(kNumberUintFlag) {
-        data_.n.u64 = u; 
+    //! Constructor for uint32_t value.
+    explicit GenericValue(uint32_t u) RAPIDJSON_NOEXCEPT : data_(), flags_(kNumberUintFlag) {
+        data_.n.u64 = static_cast<uint64_t>(u);
         if (!(u & 0x80000000))
             flags_ |= kIntFlag | kInt64Flag;
     }
@@ -609,7 +609,7 @@ public:
     }
 
     //! Assignment with primitive types.
-    /*! \tparam T Either \ref Type, \c int, \c unsigned, \c int64_t, \c uint64_t
+    /*! \tparam T Either \ref Type, \c int32_t, \c uint32_t, \c int64_t, \c uint64_t
         \param value The value to be assigned.
 
         \note The source type \c T explicitly disallows all pointer types,
@@ -716,7 +716,7 @@ public:
 #endif
 
     //! Equal-to operator with primitive types
-    /*! \tparam T Either \ref Type, \c int, \c unsigned, \c int64_t, \c uint64_t, \c double, \c true, \c false
+    /*! \tparam T Either \ref Type, \c int32_t, \c uint32_t, \c int64_t, \c uint64_t, \c double, \c true, \c false
     */
     template <typename T> RAPIDJSON_DISABLEIF_RETURN((internal::OrExpr<internal::IsPointer<T>,internal::IsGenericValue<T> >), (bool)) operator==(const T& rhs) const { return *this == GenericValue(rhs); }
 
@@ -983,7 +983,7 @@ public:
     }
 
     //! Add any primitive value as member (name-value pair) to the object.
-    /*! \tparam T Either \ref Type, \c int, \c unsigned, \c int64_t, \c uint64_t
+    /*! \tparam T Either \ref Type, \c int32_t, \c uint32_t, \c int64_t, \c uint64_t
         \param name A constant string reference as name of member.
         \param value Value of primitive type \c T as value of member
         \param allocator Allocator for reallocating memory. Commonly use GenericDocument::GetAllocator().
@@ -1136,9 +1136,9 @@ public:
 \code
 Value a(kArrayType);
 a.PushBack(123);
-int x = a[0].GetInt();              // Error: operator[ is ambiguous, as 0 also mean a null pointer of const char* type.
-int y = a[SizeType(0)].GetInt();    // Cast to SizeType will work.
-int z = a[0u].GetInt();             // This works too.
+int32_t x = a[0].GetInt();              // Error: operator[ is ambiguous, as 0 also mean a null pointer of const char* type.
+int32_t y = a[SizeType(0)].GetInt();    // Cast to SizeType will work.
+int32_t z = a[0u].GetInt();             // This works too.
 \endcode
     */
     GenericValue& operator[](SizeType index) {
@@ -1214,7 +1214,7 @@ int z = a[0u].GetInt();             // This works too.
     }
 
     //! Append a primitive value at the end of the array.
-    /*! \tparam T Either \ref Type, \c int, \c unsigned, \c int64_t, \c uint64_t
+    /*! \tparam T Either \ref Type, \c int32_t, \c uint32_t, \c int64_t, \c uint64_t
         \param value Value of primitive type T to be appended.
         \param allocator    Allocator for reallocating memory. It must be the same one as used before. Commonly use GenericDocument::GetAllocator().
         \pre IsArray() == true
@@ -1287,22 +1287,22 @@ int z = a[0u].GetInt();             // This works too.
     //!@name Number
     //@{
 
-    int GetInt() const          { RAPIDJSON_ASSERT(flags_ & kIntFlag);   return data_.n.i.i;   }
-    unsigned GetUint() const    { RAPIDJSON_ASSERT(flags_ & kUintFlag);  return data_.n.u.u;   }
+    int32_t GetInt() const      { RAPIDJSON_ASSERT(flags_ & kIntFlag);   return data_.n.i.i; }
+    uint32_t GetUint() const    { RAPIDJSON_ASSERT(flags_ & kUintFlag);  return data_.n.u.u; }
     int64_t GetInt64() const    { RAPIDJSON_ASSERT(flags_ & kInt64Flag); return data_.n.i64; }
     uint64_t GetUint64() const  { RAPIDJSON_ASSERT(flags_ & kUint64Flag); return data_.n.u64; }
 
     double GetDouble() const {
         RAPIDJSON_ASSERT(IsNumber());
         if ((flags_ & kDoubleFlag) != 0)                return data_.n.d;   // exact type, no conversion.
-        if ((flags_ & kIntFlag) != 0)                   return data_.n.i.i; // int -> double
-        if ((flags_ & kUintFlag) != 0)                  return data_.n.u.u; // unsigned -> double
-        if ((flags_ & kInt64Flag) != 0)                 return (double)data_.n.i64; // int64_t -> double (may lose precision)
-        RAPIDJSON_ASSERT((flags_ & kUint64Flag) != 0);  return (double)data_.n.u64; // uint64_t -> double (may lose precision)
+        if ((flags_ & kIntFlag) != 0)                   return static_cast<double>(data_.n.i.i); // int32_t -> double
+        if ((flags_ & kUintFlag) != 0)                  return static_cast<double>(data_.n.u.u); // uint32_t -> double
+        if ((flags_ & kInt64Flag) != 0)                 return static_cast<double>(data_.n.i64); // int64_t -> double (may lose precision)
+        RAPIDJSON_ASSERT((flags_ & kUint64Flag) != 0);  return static_cast<double>(data_.n.u64); // uint64_t -> double (may lose precision)
     }
 
-    GenericValue& SetInt(int i)             { this->~GenericValue(); new (this) GenericValue(i);    return *this; }
-    GenericValue& SetUint(unsigned u)       { this->~GenericValue(); new (this) GenericValue(u);    return *this; }
+    GenericValue& SetInt(int32_t i)         { this->~GenericValue(); new (this) GenericValue(i);    return *this; }
+    GenericValue& SetUint(uint32_t u)       { this->~GenericValue(); new (this) GenericValue(u);    return *this; }
     GenericValue& SetInt64(int64_t i64)     { this->~GenericValue(); new (this) GenericValue(i64);  return *this; }
     GenericValue& SetUint64(uint64_t u64)   { this->~GenericValue(); new (this) GenericValue(u64);  return *this; }
     GenericValue& SetDouble(double d)       { this->~GenericValue(); new (this) GenericValue(d);    return *this; }
@@ -1481,21 +1481,21 @@ private:
     union Number {
 #if RAPIDJSON_ENDIAN == RAPIDJSON_LITTLEENDIAN
         struct I {
-            int i;
+            int32_t i;
             char padding[4];
         }i;
         struct U {
-            unsigned u;
+            uint32_t u;
             char padding2[4];
         }u;
 #else
         struct I {
             char padding[4];
-            int i;
+            int32_t i;
         }i;
         struct U {
             char padding2[4];
-            unsigned u;
+            uint32_t u;
         }u;
 #endif
         int64_t i64;
@@ -1776,8 +1776,8 @@ private:
     // Implementation of Handler
     bool Null() { new (stack_.template Push<ValueType>()) ValueType(); return true; }
     bool Bool(bool b) { new (stack_.template Push<ValueType>()) ValueType(b); return true; }
-    bool Int(int i) { new (stack_.template Push<ValueType>()) ValueType(i); return true; }
-    bool Uint(unsigned i) { new (stack_.template Push<ValueType>()) ValueType(i); return true; }
+    bool Int(int32_t i) { new (stack_.template Push<ValueType>()) ValueType(i); return true; }
+    bool Uint(uint32_t i) { new (stack_.template Push<ValueType>()) ValueType(i); return true; }
     bool Int64(int64_t i) { new (stack_.template Push<ValueType>()) ValueType(i); return true; }
     bool Uint64(uint64_t i) { new (stack_.template Push<ValueType>()) ValueType(i); return true; }
     bool Double(double d) { new (stack_.template Push<ValueType>()) ValueType(d); return true; }

--- a/include/rapidjson/prettywriter.h
+++ b/include/rapidjson/prettywriter.h
@@ -70,8 +70,8 @@ public:
 
     bool Null()                 { PrettyPrefix(kNullType);   return Base::WriteNull(); }
     bool Bool(bool b)           { PrettyPrefix(b ? kTrueType : kFalseType); return Base::WriteBool(b); }
-    bool Int(int i)             { PrettyPrefix(kNumberType); return Base::WriteInt(i); }
-    bool Uint(unsigned u)       { PrettyPrefix(kNumberType); return Base::WriteUint(u); }
+    bool Int(int32_t i)         { PrettyPrefix(kNumberType); return Base::WriteInt(i); }
+    bool Uint(uint32_t u)       { PrettyPrefix(kNumberType); return Base::WriteUint(u); }
     bool Int64(int64_t i64)     { PrettyPrefix(kNumberType); return Base::WriteInt64(i64); }
     bool Uint64(uint64_t u64)   { PrettyPrefix(kNumberType); return Base::WriteUint64(u64);  }
     bool Double(double d)       { PrettyPrefix(kNumberType); return Base::WriteDouble(d); }

--- a/include/rapidjson/rapidjson.h
+++ b/include/rapidjson/rapidjson.h
@@ -49,19 +49,20 @@
 #include <cstring>  // memset(), memcpy(), memmove(), memcmp()
 
 ///////////////////////////////////////////////////////////////////////////////
-// RAPIDJSON_NO_INT64DEFINE
+// RAPIDJSON_NO_STDINT
 
-/*! \def RAPIDJSON_NO_INT64DEFINE
+/*! \def RAPIDJSON_NO_STDINT
     \ingroup RAPIDJSON_CONFIG
-    \brief Use external 64-bit integer types.
+    \brief Do not use \c stdint.h and \c inttypes.h
 
-    RapidJSON requires the 64-bit integer types \c int64_t and  \c uint64_t types
-    to be available at global scope.
+    RapidJSON uses the types \c int32_t, \c uint32_t, \c int64_t, and
+    \c uint64_t from \c stdint.h (or \c msinttypes/stdint.h on Windows).
 
-    If users have their own definition, define RAPIDJSON_NO_INT64DEFINE to
-    prevent RapidJSON from defining its own types.
+    If you prefer not to include these headers (because, for example, you have
+    your own type definitions), define \c RAPIDJSON_NO_STDINT to prevent
+    RapidJSON from including the headers.
 */
-#ifndef RAPIDJSON_NO_INT64DEFINE
+#ifndef RAPIDJSON_NO_STDINT
 //!@cond RAPIDJSON_HIDDEN_FROM_DOXYGEN
 #ifdef _MSC_VER
 #include "msinttypes/stdint.h"
@@ -73,9 +74,9 @@
 #endif
 //!@endcond
 #ifdef RAPIDJSON_DOXYGEN_RUNNING
-#define RAPIDJSON_NO_INT64DEFINE
+#define RAPIDJSON_NO_STDINT
 #endif
-#endif // RAPIDJSON_NO_INT64TYPEDEF
+#endif // RAPIDJSON_NO_STDINT
 
 ///////////////////////////////////////////////////////////////////////////////
 // RAPIDJSON_FORCEINLINE

--- a/include/rapidjson/writer.h
+++ b/include/rapidjson/writer.h
@@ -107,8 +107,8 @@ public:
 
     bool Null()                 { Prefix(kNullType);   return WriteNull(); }
     bool Bool(bool b)           { Prefix(b ? kTrueType : kFalseType); return WriteBool(b); }
-    bool Int(int i)             { Prefix(kNumberType); return WriteInt(i); }
-    bool Uint(unsigned u)       { Prefix(kNumberType); return WriteUint(u); }
+    bool Int(int32_t i)         { Prefix(kNumberType); return WriteInt(i); }
+    bool Uint(uint32_t u)       { Prefix(kNumberType); return WriteUint(u); }
     bool Int64(int64_t i64)     { Prefix(kNumberType); return WriteInt64(i64); }
     bool Uint64(uint64_t u64)   { Prefix(kNumberType); return WriteUint64(u64); }
 
@@ -195,7 +195,7 @@ protected:
         return true;
     }
 
-    bool WriteInt(int i) {
+    bool WriteInt(int32_t i) {
         char buffer[11];
         const char* end = internal::i32toa(i, buffer);
         for (const char* p = buffer; p != end; ++p)
@@ -203,7 +203,7 @@ protected:
         return true;
     }
 
-    bool WriteUint(unsigned u) {
+    bool WriteUint(uint32_t u) {
         char buffer[10];
         const char* end = internal::u32toa(u, buffer);
         for (const char* p = buffer; p != end; ++p)
@@ -341,7 +341,7 @@ private:
 // Full specialization for StringStream to prevent memory copying
 
 template<>
-inline bool Writer<StringBuffer>::WriteInt(int i) {
+inline bool Writer<StringBuffer>::WriteInt(int32_t i) {
     char *buffer = os_->Push(11);
     const char* end = internal::i32toa(i, buffer);
     os_->Pop(11 - (end - buffer));
@@ -349,7 +349,7 @@ inline bool Writer<StringBuffer>::WriteInt(int i) {
 }
 
 template<>
-inline bool Writer<StringBuffer>::WriteUint(unsigned u) {
+inline bool Writer<StringBuffer>::WriteUint(uint32_t u) {
     char *buffer = os_->Push(10);
     const char* end = internal::u32toa(u, buffer);
     os_->Pop(10 - (end - buffer));

--- a/test/perftest/misctest.cpp
+++ b/test/perftest/misctest.cpp
@@ -121,7 +121,7 @@ inline unsigned CountDecimalDigit64_enroll4(uint64_t n) {
     return count + 3;
 }
 
-inline unsigned CountDecimalDigit_fast(unsigned n) {
+inline unsigned CountDecimalDigit_fast(uint32_t n) {
     static const uint32_t powers_of_10[] = {
         0,
         10,
@@ -370,15 +370,15 @@ public:
         os_ = &os;
     }
 
-    bool WriteInt(int i) {
+    bool WriteInt(int32_t i) {
         if (i < 0) {
             os_->Put('-');
             i = -i;
         }
-        return WriteUint((unsigned)i);
+        return WriteUint(static_cast<uint32_t>(i));
     }
 
-    bool WriteUint(unsigned u) {
+    bool WriteUint(uint32_t u) {
         char buffer[10];
         char *p = buffer;
         do {
@@ -422,7 +422,7 @@ private:
 };
 
 template<>
-bool Writer1<rapidjson::StringBuffer>::WriteUint(unsigned u) {
+bool Writer1<rapidjson::StringBuffer>::WriteUint(uint32_t u) {
     char buffer[10];
     char* p = buffer;
     do {
@@ -449,19 +449,19 @@ public:
         os_ = &os;
     }
 
-    bool WriteInt(int i) {
+    bool WriteInt(int32_t i) {
         if (i < 0) {
             os_->Put('-');
             i = -i;
         }
-        return WriteUint((unsigned)i);
+        return WriteUint(static_cast<uint32_t>(i));
     }
 
-    bool WriteUint(unsigned u) {
+    bool WriteUint(uint32_t u) {
         char buffer[10];
         char* p = buffer;
         while (u >= 100) {
-            const unsigned i = (u % 100) << 1;
+            const unsigned i = static_cast<unsigned>(u % 100) << 1;
             u /= 100;
             *p++ = digits[i + 1];
             *p++ = digits[i];
@@ -469,7 +469,7 @@ public:
         if (u < 10)
             *p++ = char(u) + '0';
         else {
-            const unsigned i = u << 1;
+            const unsigned i = static_cast<unsigned>(u) << 1;
             *p++ = digits[i + 1];
             *p++ = digits[i];
         }
@@ -529,15 +529,15 @@ public:
         os_ = &os;
     }
 
-    bool WriteInt(int i) {
+    bool WriteInt(int32_t i) {
         if (i < 0) {
             os_->Put('-');
             i = -i;
         }
-        return WriteUint((unsigned)i);
+        return WriteUint(static_cast<uint32_t>(i));
     }
 
-    bool WriteUint(unsigned u) {
+    bool WriteUint(uint32_t u) {
         char buffer[10];
         char *p = buffer;
         do {
@@ -577,7 +577,7 @@ public:
     }
 
 private:
-    void WriteUintReverse(char* d, unsigned u) {
+    void WriteUintReverse(char* d, uint32_t u) {
         do {
             *--d = char(u % 10) + '0';
             u /= 10;
@@ -595,14 +595,14 @@ private:
 };
 
 template<>
-inline bool Writer3<rapidjson::StringBuffer>::WriteUint(unsigned u) {
+inline bool Writer3<rapidjson::StringBuffer>::WriteUint(uint32_t u) {
     unsigned digit = CountDecimalDigit_fast(u);
     WriteUintReverse(os_->Push(digit) + digit, u);
     return true;
 }
 
 template<>
-inline bool Writer3<rapidjson::InsituStringStream>::WriteUint(unsigned u) {
+inline bool Writer3<rapidjson::InsituStringStream>::WriteUint(uint32_t u) {
     unsigned digit = CountDecimalDigit_fast(u);
     WriteUintReverse(os_->Push(digit) + digit, u);
     return true;
@@ -633,19 +633,19 @@ public:
         os_ = &os;
     }
 
-    bool WriteInt(int i) {
+    bool WriteInt(int32_t i) {
         if (i < 0) {
             os_->Put('-');
             i = -i;
         }
-        return WriteUint((unsigned)i);
+        return WriteUint(static_cast<uint32_t>(i));
     }
 
-    bool WriteUint(unsigned u) {
+    bool WriteUint(uint32_t u) {
         char buffer[10];
         char* p = buffer;
         while (u >= 100) {
-            const unsigned i = (u % 100) << 1;
+            const unsigned i = static_cast<unsigned>(u % 100) << 1;
             u /= 100;
             *p++ = digits[i + 1];
             *p++ = digits[i];
@@ -653,7 +653,7 @@ public:
         if (u < 10)
             *p++ = char(u) + '0';
         else {
-            const unsigned i = u << 1;
+            const unsigned i = static_cast<unsigned>(u) << 1;
             *p++ = digits[i + 1];
             *p++ = digits[i];
         }
@@ -699,9 +699,9 @@ public:
     }
 
 private:
-    void WriteUintReverse(char* d, unsigned u) {
+    void WriteUintReverse(char* d, uint32_t u) {
         while (u >= 100) {
-            const unsigned i = (u % 100) << 1;
+            const unsigned i = static_cast<unsigned>(u % 100) << 1;
             u /= 100;
             *--d = digits[i + 1];
             *--d = digits[i];
@@ -710,7 +710,7 @@ private:
             *--d = char(u) + '0';
         }
         else {
-            const unsigned i = u << 1;
+            const unsigned i = static_cast<unsigned>(u) << 1;
             *--d = digits[i + 1];
             *--d = digits[i];
         }
@@ -718,7 +718,7 @@ private:
 
     void WriteUint64Reverse(char* d, uint64_t u) {
         while (u >= 100) {
-            const unsigned i = (u % 100) << 1;
+            const unsigned i = static_cast<unsigned>(u % 100) << 1;
             u /= 100;
             *--d = digits[i + 1];
             *--d = digits[i];
@@ -727,7 +727,7 @@ private:
             *--d = char(u) + '0';
         }
         else {
-            const unsigned i = u << 1;
+            const unsigned i = static_cast<unsigned>(u) << 1;
             *--d = digits[i + 1];
             *--d = digits[i];
         }
@@ -737,14 +737,14 @@ private:
 };
 
 template<>
-inline bool Writer4<rapidjson::StringBuffer>::WriteUint(unsigned u) {
+inline bool Writer4<rapidjson::StringBuffer>::WriteUint(uint32_t u) {
     unsigned digit = CountDecimalDigit_fast(u);
     WriteUintReverse(os_->Push(digit) + digit, u);
     return true;
 }
 
 template<>
-inline bool Writer4<rapidjson::InsituStringStream>::WriteUint(unsigned u) {
+inline bool Writer4<rapidjson::InsituStringStream>::WriteUint(uint32_t u) {
     unsigned digit = CountDecimalDigit_fast(u);
     WriteUintReverse(os_->Push(digit) + digit, u);
     return true;
@@ -902,7 +902,7 @@ void itoa64_Writer_InsituStringStream() {
 namespace rapidjson {
 
 template<>
-bool rapidjson::Writer<InsituStringStream>::WriteInt(int i) {
+bool rapidjson::Writer<InsituStringStream>::WriteInt(int32_t i) {
     char *buffer = os_->Push(11);
     const char* end = internal::i32toa(i, buffer);
     os_->Pop(11 - (end - buffer));
@@ -910,7 +910,7 @@ bool rapidjson::Writer<InsituStringStream>::WriteInt(int i) {
 }
 
 template<>
-bool Writer<InsituStringStream>::WriteUint(unsigned u) {
+bool Writer<InsituStringStream>::WriteUint(uint32_t u) {
     char *buffer = os_->Push(10);
     const char* end = internal::u32toa(u, buffer);
     os_->Pop(10 - (end - buffer));


### PR DESCRIPTION
Summary

* Replaces #145
* Rename `RAPIDJSON_NO_INT64DEFINE` to `RAPIDJSON_NO_STDINT` and revise documentation to address @pah's concern about unconditionally using `int32_t`/`uint32_t`.

As I discussed in #145, I think this change improves several things:

1. Better type documentation
2. The name of the macro `RAPIDJSON_NO_STDINT` more accurately describes its purpose than `RAPIDJSON_NO_INT64DEFINE` did. It disables the `#include <stdint.h>` and doesn't only disable the definition of `int64_t`/`uint64_t`. Of course, this is more significant with the usage of `int32_t`/`uint32_t`.

@pah had the concern that the type definition `int32_t` implied the implementation type would be restricted to 32 bits on a 64-bit system. I'm certain all 64-bit systems will use the most efficient implementation type for `int32_t`. To check, I looked at `stdint.h` on Mac OS X and Linux as well as `msinttypes/stdint.h`: all of them use `int`.