### PR TITLE
turn implicit integer conversions into static_casts to avoid warnings

### DIFF
--- a/include/rapidjson/internal/dtoa.h
+++ b/include/rapidjson/internal/dtoa.h
@@ -53,7 +53,7 @@ struct DiyFp {
             uint64_t u64;
         } u = { d };
 
-        int biased_e = (u.u64 & kDpExponentMask) >> kDpSignificandSize;
+        int biased_e = static_cast<int>((u.u64 & kDpExponentMask) >> kDpSignificandSize);
         uint64_t significand = (u.u64 & kDpSignificandMask);
         if (biased_e != 0) {
             f = significand + kDpHiddenBit;
@@ -78,7 +78,7 @@ struct DiyFp {
         return DiyFp(h, e + rhs.e + 64);
 #elif (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) && defined(__x86_64__)
         unsigned __int128 p = static_cast<unsigned __int128>(f) * static_cast<unsigned __int128>(rhs.f);
-        uint64_t h = p >> 64;
+        uint64_t h = static_cast<uint64_t>(p >> 64);
         uint64_t l = static_cast<uint64_t>(p);
         if (l & (uint64_t(1) << 63)) // rounding
             h++;
@@ -284,7 +284,7 @@ inline void DigitGen(const DiyFp& W, const DiyFp& Mp, uint64_t delta, char* buff
 #endif
         }
         if (d || *len)
-            buffer[(*len)++] = '0' + static_cast<char>(d);
+            buffer[(*len)++] = static_cast<char>('0' + static_cast<char>(d));
         kappa--;
         uint64_t tmp = (static_cast<uint64_t>(p1) << -one.e) + p2;
         if (tmp <= delta) {
@@ -300,7 +300,7 @@ inline void DigitGen(const DiyFp& W, const DiyFp& Mp, uint64_t delta, char* buff
         delta *= 10;
         char d = static_cast<char>(p2 >> -one.e);
         if (d || *len)
-            buffer[(*len)++] = '0' + d;
+            buffer[(*len)++] = static_cast<char>('0' + d);
         p2 &= one.f - 1;
         kappa--;
         if (p2 < delta) {
@@ -332,7 +332,7 @@ inline char* WriteExponent(int K, char* buffer) {
     }
 
     if (K >= 100) {
-        *buffer++ = '0' + static_cast<char>(K / 100);
+        *buffer++ = static_cast<char>('0' + static_cast<char>(K / 100));
         K %= 100;
         const char* d = GetDigitsLut() + K * 2;
         *buffer++ = d[0];
@@ -344,7 +344,7 @@ inline char* WriteExponent(int K, char* buffer) {
         *buffer++ = d[1];
     }
     else
-        *buffer++ = '0' + static_cast<char>(K);
+        *buffer++ = static_cast<char>('0' + static_cast<char>(K));
 
     return buffer;
 }

--- a/include/rapidjson/internal/itoa.h
+++ b/include/rapidjson/internal/itoa.h
@@ -91,7 +91,7 @@ inline char* u32toa(uint32_t value, char* buffer) {
             *buffer++ = cDigitsLut[i + 1];
         }
         else
-            *buffer++ = '0' + static_cast<char>(a);
+            *buffer++ = static_cast<char>('0' + static_cast<char>(a));
 
         const uint32_t b = value / 10000; // 0 to 9999
         const uint32_t c = value % 10000; // 0 to 9999
@@ -227,14 +227,14 @@ inline char* u64toa(uint64_t value, char* buffer) {
         value %= kTen16;
         
         if (a < 10)
-            *buffer++ = '0' + static_cast<char>(a);
+            *buffer++ = static_cast<char>('0' + static_cast<char>(a));
         else if (a < 100) {
             const uint32_t i = a << 1;
             *buffer++ = cDigitsLut[i];
             *buffer++ = cDigitsLut[i + 1];
         }
         else if (a < 1000) {
-            *buffer++ = '0' + static_cast<char>(a / 100);
+            *buffer++ = static_cast<char>('0' + static_cast<char>(a / 100));
             
             const uint32_t i = (a % 100) << 1;
             *buffer++ = cDigitsLut[i];


### PR DESCRIPTION
When the option -Wconversion is given to GCC 4.8 it will warn about implicit, narrowing integer conversions. This kind of conversion is bad because you as a reader cannot see whether the narrowing was intended or happened by accident. A simple static_cast solves the problem by making the conversion explicit for the reader and for the compiler.
It is common to compile with -Wconversion and even -Werror, so this issue can really be a show-stopper for many organizations.
The behaviour of the code should not have changed, only the warnings are gone. The unit tests are still green on my machine (Ubuntu, AMD64, GCC 4.8).
