### PR TITLE
Use -march=native for platform-specific optimizations

### DIFF
--- a/build/premake4.lua
+++ b/build/premake4.lua
@@ -64,7 +64,7 @@ solution "test"
         defines { "_CRT_SECURE_NO_WARNINGS" }
         
     configuration "gmake"
-        buildoptions "-msse4.2 -Wall -Wextra"
+        buildoptions "-march=native -Wall -Wextra"
 
     project "gtest"
         kind "StaticLib"


### PR DESCRIPTION
`-march=native` has several benefits:
- It implies `-msse4.2` if it is supported and doesn't prevent compilation where it is not.
- It enables other platform-specific optimizations.
