### PR TITLE
Use predefined macros to enable SSE with gmake

### DIFF
--- a/test/perftest/perftest.h
+++ b/test/perftest/perftest.h
@@ -31,10 +31,12 @@
 #define TEST_VERSION_CODE(x,y,z) \
   (((x)*100000) + ((y)*100) + (z))
 
-// Only gcc >4.3 supports SSE4.2
-#if TEST_RAPIDJSON && !(defined(__GNUC__) && TEST_VERSION_CODE(__GNUC__,__GNUC_MINOR__,__GNUC_PATCHLEVEL__) < TEST_VERSION_CODE(4,3,0))
-//#define RAPIDJSON_SSE2
-#define RAPIDJSON_SSE42
+// __SSE2__ and __SSE4_2__ are recognized by gcc, clang, and the Intel compiler.
+// We use -march=native with gmake to enable -msse2 and -msse4.2, if supported.
+#if defined(__SSE4_2__)
+#  define RAPIDJSON_SSE42
+#elif defined(__SSE2__)
+#  define RAPIDJSON_SSE2
 #endif
 
 #if TEST_YAJL


### PR DESCRIPTION
Enables SSE2 or SSE4.2 using standard x86 predefined macros. This plus #163 means that SSE4.2 will be enabled on most modern systems (using `gmake`). Also, it serves as useful documentation for people who want to enable SSE4.2 themselves.
