### PR TITLE
Add perf tests for EncodedInputStream and AutoUTFInputStream

### DIFF
--- a/test/perftest/rapidjsontest.cpp
+++ b/test/perftest/rapidjsontest.cpp
@@ -28,6 +28,8 @@
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/filestream.h"
 #include "rapidjson/filereadstream.h"
+#include "rapidjson/encodedstream.h"
+#include "rapidjson/memorystream.h"
 
 #ifdef RAPIDJSON_SSE2
 #define SIMD_SUFFIX(name) name##_SSE2
@@ -163,6 +165,26 @@ TEST_F(RapidJson, SIMD_SUFFIX(DocumentParse_CrtAllocator)) {
         memcpy(temp_, json_, length_ + 1);
         GenericDocument<UTF8<>, CrtAllocator> doc;
         doc.Parse(temp_);
+        ASSERT_TRUE(doc.IsObject());
+    }
+}
+
+TEST_F(RapidJson, SIMD_SUFFIX(DocumentParseEncodedInputStream_MemoryStream)) {
+    for (size_t i = 0; i < kTrialCount; i++) {
+        MemoryStream ms(json_, length_);
+        EncodedInputStream<UTF8<>, MemoryStream> is(ms);
+        Document doc;
+        doc.ParseStream<0, UTF8<> >(is);
+        ASSERT_TRUE(doc.IsObject());
+    }
+}
+
+TEST_F(RapidJson, SIMD_SUFFIX(DocumentParseAutoUTFInputStream_MemoryStream)) {
+    for (size_t i = 0; i < kTrialCount; i++) {
+        MemoryStream ms(json_, length_);
+        AutoUTFInputStream<unsigned, MemoryStream> is(ms);
+        Document doc;
+        doc.ParseStream<0, AutoUTF<unsigned> >(is);
         ASSERT_TRUE(doc.IsObject());
     }
 }


### PR DESCRIPTION
I think we need more performance tests with the different variations of parsing. Here are two more.

For the curious, here are my results:

```
$ ./perftest_release_x64_gmake
[==========] Running 23 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 23 tests from RapidJson
[ RUN      ] RapidJson.ReaderParseInsitu_DummyHandler
[       OK ] RapidJson.ReaderParseInsitu_DummyHandler (836 ms)
[ RUN      ] RapidJson.ReaderParseInsitu_DummyHandler_ValidateEncoding
[       OK ] RapidJson.ReaderParseInsitu_DummyHandler_ValidateEncoding (1278 ms)
[ RUN      ] RapidJson.ReaderParse_DummyHandler
[       OK ] RapidJson.ReaderParse_DummyHandler (819 ms)
[ RUN      ] RapidJson.ReaderParseIterative_DummyHandler
[       OK ] RapidJson.ReaderParseIterative_DummyHandler (864 ms)
[ RUN      ] RapidJson.ReaderParseIterativeInsitu_DummyHandler
[       OK ] RapidJson.ReaderParseIterativeInsitu_DummyHandler (865 ms)
[ RUN      ] RapidJson.ReaderParse_DummyHandler_ValidateEncoding
[       OK ] RapidJson.ReaderParse_DummyHandler_ValidateEncoding (1417 ms)
[ RUN      ] RapidJson.DocumentParseInsitu_MemoryPoolAllocator
[       OK ] RapidJson.DocumentParseInsitu_MemoryPoolAllocator (873 ms)
[ RUN      ] RapidJson.DocumentParseIterativeInsitu_MemoryPoolAllocator
[       OK ] RapidJson.DocumentParseIterativeInsitu_MemoryPoolAllocator (910 ms)
[ RUN      ] RapidJson.DocumentParse_MemoryPoolAllocator
[       OK ] RapidJson.DocumentParse_MemoryPoolAllocator (901 ms)
[ RUN      ] RapidJson.DocumentParseIterative_MemoryPoolAllocator
[       OK ] RapidJson.DocumentParseIterative_MemoryPoolAllocator (920 ms)
[ RUN      ] RapidJson.DocumentParse_CrtAllocator
[       OK ] RapidJson.DocumentParse_CrtAllocator (1281 ms)
[ RUN      ] RapidJson.DocumentParseEncodedInputStream_MemoryStream
[       OK ] RapidJson.DocumentParseEncodedInputStream_MemoryStream (1856 ms)
[ RUN      ] RapidJson.DocumentParseAutoUTFInputStream_MemoryStream
[       OK ] RapidJson.DocumentParseAutoUTFInputStream_MemoryStream (2926 ms)
[ RUN      ] RapidJson.DocumentTraverse
[       OK ] RapidJson.DocumentTraverse (17 ms)
[ RUN      ] RapidJson.DocumentAccept
[       OK ] RapidJson.DocumentAccept (38 ms)
[ RUN      ] RapidJson.Writer_NullStream
[       OK ] RapidJson.Writer_NullStream (116 ms)
[ RUN      ] RapidJson.Writer_StringBuffer
[       OK ] RapidJson.Writer_StringBuffer (497 ms)
[ RUN      ] RapidJson.PrettyWriter_StringBuffer
[       OK ] RapidJson.PrettyWriter_StringBuffer (567 ms)
[ RUN      ] RapidJson.internal_Pow10
[       OK ] RapidJson.internal_Pow10 (2 ms)
[ RUN      ] RapidJson.Whitespace
[       OK ] RapidJson.Whitespace (664 ms)
[ RUN      ] RapidJson.UTF8_Validate
[       OK ] RapidJson.UTF8_Validate (2906 ms)
[ RUN      ] RapidJson.FileReadStream
[       OK ] RapidJson.FileReadStream (734 ms)
[ RUN      ] RapidJson.ReaderParse_DummyHandler_FileReadStream
[       OK ] RapidJson.ReaderParse_DummyHandler_FileReadStream (1683 ms)
[----------] 23 tests from RapidJson (22970 ms total)

[----------] Global test environment tear-down
[==========] 23 tests from 1 test case ran. (22970 ms total)
[  PASSED  ] 23 tests.
```
