### PR TITLE
Fix MemoryStream::Peek() and add test for fix

### DIFF
--- a/include/rapidjson/memorystream.h
+++ b/include/rapidjson/memorystream.h
@@ -42,7 +42,7 @@ struct MemoryStream {
 
     MemoryStream(const Ch *src, size_t size) : src_(src), begin_(src), end_(src + size), size_(size) {}
 
-    Ch Peek() const { return *src_; }
+    Ch Peek() const { return (src_ == end_) ? '\0' : *src_; }
     Ch Take() { return (src_ == end_) ? '\0' : *src_++; }
     size_t Tell() const { return static_cast<size_t>(src_ - begin_); }
 

--- a/test/unittest/readertest.cpp
+++ b/test/unittest/readertest.cpp
@@ -21,6 +21,7 @@
 #include "unittest.h"
 
 #include "rapidjson/reader.h"
+#include "rapidjson/memorystream.h"
 
 using namespace rapidjson;
 
@@ -674,6 +675,15 @@ TEST(Reader, ParseObject_Error) {
 
     // Must be a comma or '}' after an object member
     TEST_ERROR(kParseErrorObjectMissCommaOrCurlyBracket, "{\"a\":1]");
+
+    // This tests that MemoryStream is checking the length in Peek().
+    {
+        MemoryStream ms("{\"a\"", 1);
+        BaseReaderHandler<> h;
+        Reader reader;
+        EXPECT_FALSE(reader.Parse<kParseStopWhenDoneFlag>(ms, h));
+        EXPECT_EQ(kParseErrorObjectMissName, reader.GetParseErrorCode());
+    }
 }
 
 #undef TEST_ERROR


### PR DESCRIPTION
`MemoryStream::Peek()` did not return `'\0'` if `src_ == end_`, but `Peek() == '\0'` is used in parsing in the `GenericReader`. Without this change, parsing with `MemoryStream` as the `InputStream` could result in a segmentation fault.
