### PR TITLE
.travis.yml: avoid Valgrind bug with '-march=native'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,10 @@ before_install:
 install: true
 
 before_script:
-  - pushd build && premake4 'gmake' && popd
+  - (cd build && premake4 'gmake')
+#   hack to avoid Valgrind bug (https://bugs.kde.org/show_bug.cgi?id=326469),
+#   exposed by merging PR#163 (using -march=native)
+  - (cd build/gmake && sed -i 's/march=native/msse4.2/' *.make)
 
 script:
   - make -C build/gmake -f test.make    config=${CONF}${BITS}


### PR DESCRIPTION
The switch in #163 to `-march=native` exposed a Valgrind bug on the Travis CI machines, see e.g. [build 436](https://travis-ci.org/miloyip/rapidjson/builds/38787102) and following:

```
vex amd64->IR: unhandled instruction bytes: 0xC4 0xE1 0xFB 0x2A 0x45 0x80 0xEB 0x1A
==3841== valgrind: Unrecognised instruction at address 0x418d6b.
```

Possibly fixed in Valgrind 3.10, see upstream bug https://bugs.kde.org/show_bug.cgi?id=326469.

This pull-request temporarily changes the `-march=native` flags back to `-msse4.2` after the generation of the gmake files.  I still think that the original change in #163 is reasonable.
