### PR TITLE
GenericValue: improve operator[] disambiguation

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -121,9 +121,7 @@ In the following, details about querying individual types are discussed.
 
 By default, `SizeType` is typedef of `unsigned`. In most systems, array is limited to store up to 2^32-1 elements.
 
-You may access the elements in array by integer literal, for example, `a[1]`, `a[2]`. However, `a[0]` will generate a compiler error. It is because two overloaded operators `operator[](SizeType)` and `operator[](const char*)` is available, and C++ can treat `0` as a null pointer. Workarounds:
-* `a[SizeType(0)]`
-* `a[0u]`
+You may access the elements in array by integer literal, for example, `a[0]`, `a[1]`, `a[2]`.
 
 Array is similar to `std::vector`, instead of using indices, you may also use iterator to access all the elements.
 ~~~~~~~~~~cpp

--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -795,15 +795,6 @@ public:
     //! Check whether the object is empty.
     bool ObjectEmpty() const { RAPIDJSON_ASSERT(IsObject()); return data_.o.size == 0; }
 
-    template <typename T>
-    GenericValue& operator[](T t) {
-	    return DoIndex(t, internal::IsPointer<T>());
-    }
-
-    template <typename T>
-    const GenericValue& operator[](T t) const { return const_cast<GenericValue&>(*this)[t]; }
-
-private:
     //! Get the value associated with the name.
     /*!
         \note In version 0.1x, if the member is not found, this function returns a null value. This makes issue 7.
@@ -812,20 +803,14 @@ private:
         A better approach is to use FindMember().
         \note Linear time complexity.
     */
-
-    GenericValue& DoIndex(const Ch* name, internal::TrueType) {
+    template <typename T>
+    RAPIDJSON_DISABLEIF_RETURN((internal::NotExpr<internal::IsSame<typename internal::RemoveConst<T>::Type, Ch> >),(GenericValue&)) operator[](T* name) {
         GenericValue n(StringRef(name));
         return (*this)[n];
     }
+    template <typename T>
+    RAPIDJSON_DISABLEIF_RETURN((internal::NotExpr<internal::IsSame<typename internal::RemoveConst<T>::Type, Ch> >),(const GenericValue&)) operator[](T* name) const { return const_cast<GenericValue&>(*this)[name]; }
 
-    //! Get an element from array by index.
-    /*! \param index Zero-based index of element.
-    */
-    GenericValue& DoIndex(SizeType index, internal::FalseType) {
-        RAPIDJSON_ASSERT(IsArray());
-        RAPIDJSON_ASSERT(index < data_.a.size);
-        return data_.a.elements[index];
-    }
 
 public:
     // This version is faster because it does not need a StrLen(). 
@@ -1149,6 +1134,16 @@ public:
             data_.a.elements[i].~GenericValue();
         data_.a.size = 0;
     }
+
+    //! Get an element from array by index.
+    /*! \param index Zero-based index of element.
+    */
+    GenericValue& operator[](SizeType index) {
+        RAPIDJSON_ASSERT(IsArray());
+        RAPIDJSON_ASSERT(index < data_.a.size);
+        return data_.a.elements[index];
+    }
+    const GenericValue& operator[](SizeType index) const { return const_cast<GenericValue&>(*this)[index]; }
 
     //! Element iterator
     /*! \pre IsArray() == true */


### PR DESCRIPTION
In the original disambiguation fix for `GenericValue::operator[]` (#170), the documentation has been missing, which led to quite badly rendered [Doxygen pages](http://miloyip.github.io/rapidjson/classrapidjson_1_1_generic_value.html).

During a cleanup, I've realized that a much simpler disambiguation is possible:

``` cpp
  GenericValue& operator[](SizeType idx); // array
  template <typename T>
  GenericValue& operator[](T* name);      // object
```

This approach works, as non-template functions are preferred over template functions.
In order to improve the error messages, the pointer type is restricted to `(const) Ch`.

Update `tutorial.md` to drop the ambiguity warning.
