### PR TITLE
Use 'deprecated' instead of 'depreciated'

### DIFF
--- a/include/rapidjson/filestream.h
+++ b/include/rapidjson/filestream.h
@@ -26,7 +26,7 @@
 
 namespace rapidjson {
 
-//! (Depreciated) Wrapper of C file stream for input or output.
+//! (Deprecated) Wrapper of C file stream for input or output.
 /*!
     This simple wrapper does not check the validity of the stream.
     \note implements Stream concept

--- a/test/perftest/rapidjsontest.cpp
+++ b/test/perftest/rapidjsontest.cpp
@@ -315,7 +315,7 @@ TEST_F(RapidJson, UTF8_Validate) {
     }
 }
 
-// Depreciated.
+// Deprecated.
 //TEST_F(RapidJson, FileStream_Read) {
 //  for (size_t i = 0; i < kTrialCount; i++) {
 //      FILE *fp = fopen(filename_, "rb");

--- a/test/unittest/filestreamtest.cpp
+++ b/test/unittest/filestreamtest.cpp
@@ -60,7 +60,7 @@ protected:
     size_t length_;
 };
 
-// Depreciated
+// Deprecated
 //TEST_F(FileStreamTest, FileStream_Read) {
 //  FILE *fp = fopen(filename_, "rb");
 //  ASSERT_TRUE(fp != 0);


### PR DESCRIPTION
_Deprecated_ is standardized in English software terminology.
