### PR TITLE
Use absolute path for the link to examples

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -97,4 +97,4 @@ The following diagram shows the process.
 
 ![simpledom](doc/diagram/simpledom.png)
 
-More [examples](example/) are available.
+More [examples](https://github.com/miloyip/rapidjson/tree/master/example) are available.


### PR DESCRIPTION
So the example link in documentation will always point to correct place.
