### PR TITLE
Wrapping raw delete calls inside conditionals.

### DIFF
--- a/include/rapidjson/allocators.h
+++ b/include/rapidjson/allocators.h
@@ -135,7 +135,12 @@ public:
     */
     ~MemoryPoolAllocator() {
         Clear();
-        delete ownBaseAllocator_;
+
+        // Normally "delete 0" is ok, but in this case we might be using
+        // custom allocation that doesn't like new/delete being called,
+        // so only call delete if we called new above.
+        if (ownBaseAllocator_ != 0)
+            delete ownBaseAllocator_;
     }
 
     //! Deallocates all memory chunks, excluding the user-supplied buffer.

--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -1875,7 +1875,11 @@ private:
     }
 
     void Destroy() {
-        delete ownAllocator_;
+        // Normally "delete 0" is ok, but in this case we might be using
+        // custom allocation that doesn't like new/delete being called,
+        // so only call delete if we called new above.
+        if (ownAllocator_ != 0)
+            delete ownAllocator_;
     }
 
     static const size_t kDefaultStackCapacity = 1024;

--- a/include/rapidjson/internal/stack.h
+++ b/include/rapidjson/internal/stack.h
@@ -162,7 +162,12 @@ private:
 
     void Destroy() {
         Allocator::Free(stack_);
-        delete ownAllocator; // Only delete if it is owned by the stack
+
+        // Normally "delete 0" is ok, but in this case we might be using
+        // custom allocation that doesn't like new/delete being called,
+        // so only call delete if we called new above.
+        if (ownAllocator != 0)
+            delete ownAllocator; // Only delete if it is owned by the stack
     }
 
     // Prohibit copy constructor & assignment operator.


### PR DESCRIPTION
 I'm using rapidjson with a game engine with very tightly controlled memory management, to the point where the new/delete operators inside the game loop cause assertions. Other systems that use custom allocators might also have similar situations if they're not just overriding global new/delete, so rapidjson's allocator code should only call delete if it has to.
