### PR TITLE
Add customization macros for global new/delete

### DIFF
--- a/include/rapidjson/allocators.h
+++ b/include/rapidjson/allocators.h
@@ -105,7 +105,7 @@ public:
         chunkHead_(0), chunk_capacity_(chunkSize), userBuffer_(0), baseAllocator_(baseAllocator), ownBaseAllocator_(0)
     {
         if (!baseAllocator_)
-            ownBaseAllocator_ = baseAllocator_ = new BaseAllocator();
+            ownBaseAllocator_ = baseAllocator_ = RAPIDJSON_NEW(BaseAllocator());
         AddChunk(chunk_capacity_);
     }
 
@@ -135,7 +135,7 @@ public:
     */
     ~MemoryPoolAllocator() {
         Clear();
-        delete ownBaseAllocator_;
+        RAPIDJSON_DELETE(ownBaseAllocator_);
     }
 
     //! Deallocates all memory chunks, excluding the user-supplied buffer.

--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -1634,7 +1634,7 @@ public:
         allocator_(allocator), ownAllocator_(0), stack_(stackAllocator, stackCapacity), parseResult_()
     {
         if (!allocator_)
-            ownAllocator_ = allocator_ = new Allocator();
+            ownAllocator_ = allocator_ = RAPIDJSON_NEW(Allocator());
     }
 
 #if RAPIDJSON_HAS_CXX11_RVALUE_REFS
@@ -1875,7 +1875,7 @@ private:
     }
 
     void Destroy() {
-        delete ownAllocator_;
+        RAPIDJSON_DELETE(ownAllocator_);
     }
 
     static const size_t kDefaultStackCapacity = 1024;

--- a/include/rapidjson/internal/stack.h
+++ b/include/rapidjson/internal/stack.h
@@ -38,7 +38,7 @@ public:
     Stack(Allocator* allocator, size_t stackCapacity) : allocator_(allocator), ownAllocator(0), stack_(0), stackTop_(0), stackEnd_(0), initialCapacity_(stackCapacity) {
         RAPIDJSON_ASSERT(stackCapacity > 0);
         if (!allocator_)
-            ownAllocator = allocator_ = new Allocator();
+            ownAllocator = allocator_ = RAPIDJSON_NEW(Allocator());
     }
 
 #if RAPIDJSON_HAS_CXX11_RVALUE_REFS
@@ -162,7 +162,7 @@ private:
 
     void Destroy() {
         Allocator::Free(stack_);
-        delete ownAllocator; // Only delete if it is owned by the stack
+        RAPIDJSON_DELETE(ownAllocator); // Only delete if it is owned by the stack
     }
 
     // Prohibit copy constructor & assignment operator.

--- a/include/rapidjson/rapidjson.h
+++ b/include/rapidjson/rapidjson.h
@@ -401,6 +401,18 @@ template<int x> struct StaticAssertTest {};
 //!@endcond
 
 ///////////////////////////////////////////////////////////////////////////////
+// new/delete
+
+#ifndef RAPIDJSON_NEW
+///! customization point for global \c new
+#define RAPIDJSON_NEW(x) new x
+#endif
+#ifndef RAPIDJSON_DELETE
+///! customization point for global \c delete
+#define RAPIDJSON_DELETE(x) delete x
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
 // Allocators and Encodings
 
 #include "allocators.h"


### PR DESCRIPTION
As mentioned in #181, some environments may require adaptations to the internal calls to the global `new`/`delete` operators, like adding explicit `NULL` checks to `delete.

This patch adds two new macros
- `RAPIDJSON_NEW(x)`
- `RAPIDJSON_DELETE(x)`

to allow user-defined expressions in these cases.

This fixes #181 in an alternative manner.
