### PR TITLE
Add unit tests for StringBuffer

### DIFF
--- a/test/unittest/stringbuffertest.cpp
+++ b/test/unittest/stringbuffertest.cpp
@@ -1,0 +1,113 @@
+// Copyright (C) 2011 Milo Yip
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "unittest.h"
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/writer.h"
+
+using namespace rapidjson;
+
+TEST(StringBuffer, InitialSize) {
+  StringBuffer buffer;
+  EXPECT_EQ(0u, buffer.GetSize());
+  EXPECT_STREQ("", buffer.GetString());
+}
+
+TEST(StringBuffer, Put) {
+  StringBuffer buffer;
+  buffer.Put('A');
+
+  EXPECT_EQ(1u, buffer.GetSize());
+  EXPECT_STREQ("A", buffer.GetString());
+}
+
+TEST(StringBuffer, Clear) {
+  StringBuffer buffer;
+  buffer.Put('A');
+  buffer.Put('B');
+  buffer.Put('C');
+  buffer.Clear();
+
+  EXPECT_EQ(0u, buffer.GetSize());
+  EXPECT_STREQ("", buffer.GetString());
+}
+
+TEST(StringBuffer, Push) {
+  StringBuffer buffer;
+  buffer.Push(5);
+
+  EXPECT_EQ(5u, buffer.GetSize());
+}
+
+TEST(StringBuffer, Pop) {
+  StringBuffer buffer;
+  buffer.Put('A');
+  buffer.Put('B');
+  buffer.Put('C');
+  buffer.Put('D');
+  buffer.Put('E');
+  buffer.Pop(3);
+
+  EXPECT_EQ(2u, buffer.GetSize());
+  EXPECT_STREQ("AB", buffer.GetString());
+}
+
+#if RAPIDJSON_HAS_CXX11_RVALUE_REFS
+TEST(StringBuffer, MoveConstructor) {
+  StringBuffer x;
+  x.Put('A');
+  x.Put('B');
+  x.Put('C');
+  x.Put('D');
+
+  EXPECT_EQ(4u, x.GetSize());
+  EXPECT_STREQ("ABCD", x.GetString());
+
+  // StringBuffer y(x); // should not compile
+  StringBuffer y(std::move(x));
+  EXPECT_EQ(0u, x.GetSize());
+  EXPECT_EQ(4u, y.GetSize());
+  EXPECT_STREQ("ABCD", y.GetString());
+
+  // StringBuffer z = y; // should not compile
+  StringBuffer z = std::move(y);
+  EXPECT_EQ(0u, y.GetSize());
+  EXPECT_EQ(4u, z.GetSize());
+  EXPECT_STREQ("ABCD", z.GetString());
+}
+
+TEST(StringBuffer, MoveAssignment) {
+  StringBuffer x;
+  x.Put('A');
+  x.Put('B');
+  x.Put('C');
+  x.Put('D');
+
+  EXPECT_EQ(4u, x.GetSize());
+  EXPECT_STREQ("ABCD", x.GetString());
+
+  StringBuffer y;
+  // y = x; // should not compile
+  y = std::move(x);
+  EXPECT_EQ(0u, x.GetSize());
+  EXPECT_EQ(4u, y.GetSize());
+  EXPECT_STREQ("ABCD", y.GetString());
+}
+#endif // RAPIDJSON_HAS_CXX11_RVALUE_REFS


### PR DESCRIPTION
I want C++11 move semantics from `GenericStringBuffer`. Looking at the code, it doesn't seem to provide this.

I wrote a unit test, expecting it to fail, and to my surprise it didn't!

So here is the test. It extends the coverage a little, although `StringBuffer` is quite trivial really.

Perhaps someone could explain to me why the struct seemingly behaves according to C++11 move semantics. Is it simply that all its members are moveable, so there is a default move ctor generated?
