### PR TITLE
Add initial CMake build support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,5 +74,8 @@ include_directories(SYSTEM ${gtest_SOURCE_DIR}/include)
 add_executable(unittests ${UNIT_TEST_SOURCE_FILES})
 add_executable(perftests ${PERF_TEST_SOURCE_FILES})
 
+set_target_properties(unittests PROPERTIES COMPILE_FLAGS "-march=native -Wall -Wextra -Werror -Weffc++ -Wswitch-default")
+set_target_properties(perftests PROPERTIES COMPILE_FLAGS "-march=native -Wall -Wextra -Werror -Weffc++ -Wswitch-default")
+
 target_link_libraries(unittests pthread gtest)
 target_link_libraries(perftests pthread gtest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,42 +10,14 @@ endif(BUILD_CXX11)
 
 add_subdirectory(thirdparty/gtest)
 
-set(HEADERS
-    include/rapidjson/error/en.h
-    include/rapidjson/error/error.h
-    include/rapidjson/internal/dtoa.h
-    include/rapidjson/internal/itoa.h
-    include/rapidjson/internal/meta.h
-    include/rapidjson/internal/pow10.h
-    include/rapidjson/internal/stack.h
-    include/rapidjson/internal/strfunc.h
-    include/rapidjson/msinttypes/inttypes.h
-    include/rapidjson/msinttypes/stdint.h
-    include/rapidjson/allocators.h
-    include/rapidjson/document.h
-    include/rapidjson/encodedstream.h
-    include/rapidjson/encodings.h
-    include/rapidjson/filereadstream.h
-    include/rapidjson/filestream.h
-    include/rapidjson/filewritestream.h
-    include/rapidjson/memorybuffer.h
-    include/rapidjson/memorystream.h
-    include/rapidjson/prettywriter.h
-    include/rapidjson/rapidjson.h
-    include/rapidjson/reader.h
-    include/rapidjson/stringbuffer.h
-    include/rapidjson/writer.h)
 
 set(PERF_TEST_SOURCE_FILES
-    ${HEADERS}
     test/perftest/misctest.cpp
     test/perftest/perftest.cpp
-    test/perftest/perftest.h
     test/perftest/platformtest.cpp
     test/perftest/rapidjsontest.cpp)
 
 set(UNIT_TEST_SOURCE_FILES
-    ${HEADERS}
     test/unittest/documenttest.cpp
     test/unittest/encodedstreamtest.cpp
     test/unittest/encodingstest.cpp
@@ -53,7 +25,6 @@ set(UNIT_TEST_SOURCE_FILES
     test/unittest/jsoncheckertest.cpp
     test/unittest/readertest.cpp
     test/unittest/unittest.cpp
-    test/unittest/unittest.h
     test/unittest/valuetest.cpp
     test/unittest/writertest.cpp)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,79 @@
+cmake_minimum_required(VERSION 2.8.4)
+
+project(rapidjson)
+
+set(BUILD_CXX11 ON CACHE BOOL "Choose whether to build for C++11")
+
+if (BUILD_CXX11)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+endif(BUILD_CXX11)
+
+set(HEADERS
+    include/rapidjson/error/en.h
+    include/rapidjson/error/error.h
+    include/rapidjson/internal/dtoa.h
+    include/rapidjson/internal/itoa.h
+    include/rapidjson/internal/meta.h
+    include/rapidjson/internal/pow10.h
+    include/rapidjson/internal/stack.h
+    include/rapidjson/internal/strfunc.h
+    include/rapidjson/msinttypes/inttypes.h
+    include/rapidjson/msinttypes/stdint.h
+    include/rapidjson/allocators.h
+    include/rapidjson/document.h
+    include/rapidjson/encodedstream.h
+    include/rapidjson/encodings.h
+    include/rapidjson/filereadstream.h
+    include/rapidjson/filestream.h
+    include/rapidjson/filewritestream.h
+    include/rapidjson/memorybuffer.h
+    include/rapidjson/memorystream.h
+    include/rapidjson/prettywriter.h
+    include/rapidjson/rapidjson.h
+    include/rapidjson/reader.h
+    include/rapidjson/stringbuffer.h
+    include/rapidjson/writer.h)
+
+set(PERF_TEST_SOURCE_FILES
+    ${HEADERS}
+    thirdparty/gtest/src/gtest-all.cc
+    test/perftest/misctest.cpp
+    test/perftest/perftest.cpp
+    test/perftest/perftest.h
+    test/perftest/platformtest.cpp
+    test/perftest/rapidjsontest.cpp)
+
+set(UNIT_TEST_SOURCE_FILES
+    ${HEADERS}
+    thirdparty/gtest/src/gtest-all.cc
+    test/unittest/documenttest.cpp
+    test/unittest/encodedstreamtest.cpp
+    test/unittest/encodingstest.cpp
+    test/unittest/filestreamtest.cpp
+    test/unittest/jsoncheckertest.cpp
+    test/unittest/readertest.cpp
+    test/unittest/unittest.cpp
+    test/unittest/unittest.h
+    test/unittest/valuetest.cpp
+    test/unittest/writertest.cpp)
+
+include_directories(include)
+
+add_executable(example_capitalize    ${HEADERS} example/capitalize/capitalize.cpp)
+add_executable(example_condense      ${HEADERS} example/condense/condense.cpp)
+add_executable(example_messagereader ${HEADERS} example/messagereader/messagereader.cpp)
+add_executable(example_pretty        ${HEADERS} example/pretty/pretty.cpp)
+add_executable(example_prettyauto    ${HEADERS} example/prettyauto/prettyauto.cpp)
+add_executable(example_serialize     ${HEADERS} example/serialize/serialize.cpp)
+add_executable(example_simpledom     ${HEADERS} example/simpledom/simpledom.cpp)
+add_executable(example_simplereader  ${HEADERS} example/simplereader/simplereader.cpp)
+add_executable(example_simplewriter  ${HEADERS} example/simplewriter/simplewriter.cpp)
+
+include_directories(SYSTEM thirdparty/gtest/include)
+include_directories(thirdparty/gtest)
+
+add_executable(unittests ${UNIT_TEST_SOURCE_FILES})
+add_executable(perftests ${PERF_TEST_SOURCE_FILES})
+
+target_link_libraries(unittests pthread)
+target_link_libraries(perftests pthread)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ set(UNIT_TEST_SOURCE_FILES
     test/unittest/filestreamtest.cpp
     test/unittest/jsoncheckertest.cpp
     test/unittest/readertest.cpp
+    test/unittest/stringbuffertest.cpp
     test/unittest/unittest.cpp
     test/unittest/valuetest.cpp
     test/unittest/writertest.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,14 +2,13 @@ cmake_minimum_required(VERSION 2.8.4)
 
 project(rapidjson)
 
-set(BUILD_CXX11 ON CACHE BOOL "Choose whether to build for C++11")
+set(BUILD_CXX11 ON CACHE BOOL "Whether to build using C++11")
 
 if (BUILD_CXX11)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 endif(BUILD_CXX11)
 
 add_subdirectory(thirdparty/gtest)
-
 
 set(PERF_TEST_SOURCE_FILES
     test/perftest/misctest.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ if (BUILD_CXX11)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 endif(BUILD_CXX11)
 
+add_subdirectory(thirdparty/gtest)
+
 set(HEADERS
     include/rapidjson/error/en.h
     include/rapidjson/error/error.h
@@ -36,7 +38,6 @@ set(HEADERS
 
 set(PERF_TEST_SOURCE_FILES
     ${HEADERS}
-    thirdparty/gtest/src/gtest-all.cc
     test/perftest/misctest.cpp
     test/perftest/perftest.cpp
     test/perftest/perftest.h
@@ -45,7 +46,6 @@ set(PERF_TEST_SOURCE_FILES
 
 set(UNIT_TEST_SOURCE_FILES
     ${HEADERS}
-    thirdparty/gtest/src/gtest-all.cc
     test/unittest/documenttest.cpp
     test/unittest/encodedstreamtest.cpp
     test/unittest/encodingstest.cpp
@@ -69,11 +69,10 @@ add_executable(example_simpledom     ${HEADERS} example/simpledom/simpledom.cpp)
 add_executable(example_simplereader  ${HEADERS} example/simplereader/simplereader.cpp)
 add_executable(example_simplewriter  ${HEADERS} example/simplewriter/simplewriter.cpp)
 
-include_directories(SYSTEM thirdparty/gtest/include)
-include_directories(thirdparty/gtest)
+include_directories(SYSTEM ${gtest_SOURCE_DIR}/include)
 
 add_executable(unittests ${UNIT_TEST_SOURCE_FILES})
 add_executable(perftests ${PERF_TEST_SOURCE_FILES})
 
-target_link_libraries(unittests pthread)
-target_link_libraries(perftests pthread)
+target_link_libraries(unittests pthread gtest)
+target_link_libraries(perftests pthread gtest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,3 +50,5 @@ set_target_properties(perftests PROPERTIES COMPILE_FLAGS "-march=native -Wall -W
 
 target_link_libraries(unittests pthread gtest)
 target_link_libraries(perftests pthread gtest)
+
+add_custom_target(runtests ALL ./unittests DEPENDS unittests)


### PR DESCRIPTION
This CMakeLists.txt` provides targets for `unittests`, `perftests` and all example programs.

Note that this file does not copy the `bin` folder contents to the target directory, which only applies if you do out-of-source builds. In which case you may copy the folder manually, or ideally update `CMakeLists.txt` to perform this. I didn't manage to get this to work.

It's possible the minimum CMake version required is actually lower than that published, but I cannot test. Users of this file on earlier versions should modify this if earlier versions do in fact work.

To use:

    rapidjson$ mkdir out
    rapidjson$ cd out
    rapidjson/out$ cmake ..
    rapidjson/out$ make unittests

This CMake file has also been tested with beta builds of the new CLion IDE and works well.

You may also configure the build using a tool such as `ccmake`.

    rapidjson/out$ ccmake .