### PR TITLE
DocumentMove tests: compiler error due to -Wsign-compare

### DIFF
--- a/test/unittest/documenttest.cpp
+++ b/test/unittest/documenttest.cpp
@@ -313,7 +313,7 @@ TYPED_TEST(DocumentMove, MoveConstructorStack) {
     GenericStringStream<Encoding> is("[\"one\", \"two\", \"three\"]");
     reader.template Parse<kParseDefaultFlags>(is, a);
     size_t capacity = a.GetStackCapacity();
-    EXPECT_GT(capacity, 0);
+    EXPECT_GT(capacity, 0u);
 
     Document b(std::move(a));
     EXPECT_EQ(a.GetStackCapacity(), defaultCapacity);
@@ -405,7 +405,7 @@ TYPED_TEST(DocumentMove, MoveAssignmentStack) {
     GenericStringStream<Encoding> is("[\"one\", \"two\", \"three\"]");
     reader.template Parse<kParseDefaultFlags>(is, a);
     size_t capacity = a.GetStackCapacity();
-    EXPECT_GT(capacity, 0);
+    EXPECT_GT(capacity, 0u);
 
     Document b;
     b = std::move(a);


### PR DESCRIPTION
On GCC 4.9, the `documenttest.cpp` fails to compile in C++11 mode, as the `MoveConstructor/Assignment` tests contain left-over comparisons between signed and unsigned expressions:

```
In file included from ../../test/unittest/unittest.h:43:0,
                 from ../../test/unittest/documenttest.cpp:21:
../../thirdparty/gtest/include/gtest/gtest.h: In instantiation of ‘testing::AssertionResult testing::internal::CmpHelperGT(const char*, const char*, const T1&, const T2&) [with T1 = unsigned int; T2 = int]’:
../../test/unittest/documenttest.cpp:408:5:   required from ‘void DocumentMove_MoveAssignmentStack_Test<gtest_TypeParam_>::TestBody() [with gtest_TypeParam_ = rapidjson::MemoryPoolAllocator<>]’
../../test/unittest/documenttest.cpp:419:1:   required from here
../../thirdparty/gtest/include/gtest/gtest.h:1601:28: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
 GTEST_IMPL_CMP_HELPER_(GT, >);

```
