### PR TITLE
GenericDocument: explicitly prohibit copying

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -1862,6 +1862,8 @@ private:
     }
 
 private:
+    //! Prohibit copying
+    GenericDocument(const GenericDocument&);
     //! Prohibit assignment
     GenericDocument& operator=(const GenericDocument&);
 


### PR DESCRIPTION
In order to avoid confusing warnings about copying being implicitly deleted, add an explicit, private copy-constructor declaration (without definition) to `GenericDocument`. See #201.
