### PR TITLE
Fix two warnings

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -285,7 +285,7 @@ struct GenericStringRef {
     template<SizeType N>
     GenericStringRef(const CharType (&str)[N]) RAPIDJSON_NOEXCEPT
         : s(str), length(N-1) {}
-    
+
     GenericStringRef(const GenericStringRef& rhs) RAPIDJSON_NOEXCEPT
           : s(rhs.s), length(rhs.length) {}
 

--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -285,6 +285,9 @@ struct GenericStringRef {
     template<SizeType N>
     GenericStringRef(const CharType (&str)[N]) RAPIDJSON_NOEXCEPT
         : s(str), length(N-1) {}
+    
+    GenericStringRef(const GenericStringRef& rhs) RAPIDJSON_NOEXCEPT
+          : s(rhs.s), length(rhs.length) {}
 
     //! Explicitly create string reference from \c const character pointer
     /*!

--- a/include/rapidjson/internal/biginteger.h
+++ b/include/rapidjson/internal/biginteger.h
@@ -53,6 +53,12 @@ public:
             AppendDecimal64(decimals + i, decimals + i + length);
     }
 
+    BigInteger& operator=(const BigInteger& rhs) {
+        count_ = rhs.count_;
+        std::memcpy(digits_, rhs.digits_, count_ * sizeof(Type));
+        return *this;
+    }
+
     BigInteger& operator=(uint64_t u) {
         digits_[0] = u;            
         count_ = 1;

--- a/include/rapidjson/internal/biginteger.h
+++ b/include/rapidjson/internal/biginteger.h
@@ -55,7 +55,7 @@ public:
 
     BigInteger& operator=(const BigInteger& rhs) {
         count_ = rhs.count_;
-        std::memcpy(digits_, rhs.digits_, count_ * sizeof(Type));
+        std::memmove(digits_, rhs.digits_, count_ * sizeof(Type));
         return *this;
     }
 


### PR DESCRIPTION
Change-Id: I555fb66e1576ac96808b498abfb41e07ec319c36

Fixes on clang35 with c++0x:
definition of implicit copy constructor for 'GenericStringRef<char>' is deprecated because it has a user-declared copy assignment operator [-Werror,-Wdeprecated]

definition of implicit copy assignment operator for 'BigInteger' is deprecated because it has a user-declared copy constructor [-Werror,-Wdeprecated]