### PR TITLE
Fix an issue with building a reader on Windows x64. 

### DIFF
--- a/include/rapidjson/internal/biginteger.h
+++ b/include/rapidjson/internal/biginteger.h
@@ -23,6 +23,10 @@
 
 #include "../rapidjson.h"
 
+#if defined(_MSC_VER) && defined(_M_AMD64)
+#include <intrin.h> // for _umul128
+#endif
+
 RAPIDJSON_NAMESPACE_BEGIN
 namespace internal {
 


### PR DESCRIPTION
rapidjson/reader.h requires  <intrin.h> to be included or _umul128 will be undefined. Below is a minimal example module with the relevant build log:

**lm_jsonreader.cpp:**
--------
#include "lm_jsonreader.h"

#include "rapidjson/reader.h"
--------

**Build log:**
-------
Build started 1/7/2015 1:55:43 PM.
ClCompile:
  lm_jsonreader.cpp
c:\users\ez122\source\rapidjson\include\rapidjson\internal\biginteger.h(252): error C3861: '_umul128': identifier not found
-------