### PR TITLE
Reader::Parse{Array,Object}: simplify switch

### DIFF
--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -512,8 +512,7 @@ private:
                 case '}': 
                     if (!handler.EndObject(memberCount))
                         RAPIDJSON_PARSE_ERROR(kParseErrorTermination, is.Tell());
-                    else
-                        return;
+                    return;
                 default:  RAPIDJSON_PARSE_ERROR(kParseErrorObjectMissCommaOrCurlyBracket, is.Tell());
             }
         }
@@ -549,8 +548,7 @@ private:
                 case ']': 
                     if (!handler.EndArray(elementCount))
                         RAPIDJSON_PARSE_ERROR(kParseErrorTermination, is.Tell());
-                    else
-                        return;
+                    return;
                 default:  RAPIDJSON_PARSE_ERROR(kParseErrorArrayMissCommaOrSquareBracket, is.Tell());
             }
         }


### PR DESCRIPTION
By replacing the `else return;` paths with a simple `return;`, the Coverity warnings reported in #223 should be silenced.

Closes #223.

_Edit_: Fixed initially failing implementation.