### PR TITLE
Correct Value(kStringType) and more assertions

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -457,11 +457,15 @@ public:
     */
     explicit GenericValue(Type type) RAPIDJSON_NOEXCEPT : data_(), flags_() {
         static const unsigned defaultFlags[7] = {
-            kNullFlag, kFalseFlag, kTrueFlag, kObjectFlag, kArrayFlag, kConstStringFlag,
+            kNullFlag, kFalseFlag, kTrueFlag, kObjectFlag, kArrayFlag, kShortStringFlag,
             kNumberAnyFlag
         };
         RAPIDJSON_ASSERT(type <= kNumberType);
         flags_ = defaultFlags[type];
+
+        // Use ShortString to store empty string.
+        if (type == kStringType)
+            data_.ss.SetLength(0);
     }
 
     //! Explicit copy constructor (with allocator)
@@ -1399,6 +1403,7 @@ public:
             if (!handler.StartObject())
                 return false;
             for (ConstMemberIterator m = MemberBegin(); m != MemberEnd(); ++m) {
+                RAPIDJSON_ASSERT(m->name.IsString()); // User may change the type of name by MemberIterator.
                 if (!handler.Key(m->name.GetString(), m->name.GetStringLength(), (m->name.flags_ & kCopyFlag) != 0))
                     return false;
                 if (!m->value.Accept(handler))

--- a/test/unittest/documenttest.cpp
+++ b/test/unittest/documenttest.cpp
@@ -212,6 +212,18 @@ TEST(Document, AcceptWriter) {
     EXPECT_EQ("{\"hello\":\"world\",\"t\":true,\"f\":false,\"n\":null,\"i\":123,\"pi\":3.1416,\"a\":[1,2,3,4]}", os.str());
 }
 
+// Issue 226: Value of string type should not point to NULL
+TEST(Document, AssertAcceptInvalidNameType) {
+    Document doc;
+    doc.SetObject();
+    doc.AddMember("a", 0, doc.GetAllocator());
+    doc.FindMember("a")->name.SetNull(); // Change name to non-string type.
+
+    OutputStringStream os;
+    Writer<OutputStringStream> writer(os);
+    ASSERT_THROW(doc.Accept(writer), AssertException);
+}
+
 // Issue 44:    SetStringRaw doesn't work with wchar_t
 TEST(Document, UTF16_Document) {
     GenericDocument< UTF16<> > json;

--- a/test/unittest/valuetest.cpp
+++ b/test/unittest/valuetest.cpp
@@ -600,7 +600,7 @@ TEST(Value, String) {
     // Constructor with type
     Value y(kStringType);
     EXPECT_TRUE(y.IsString());
-    EXPECT_EQ(0, y.GetString());
+    EXPECT_STREQ("", y.GetString());    // Empty string should be "" instead of 0 (issue 226)
     EXPECT_EQ(0u, y.GetStringLength());
 
     // SetConsttring()
@@ -675,6 +675,12 @@ TEST(Value, String) {
         TestEqual(vs0, vs1);
     }
 #endif // RAPIDJSON_HAS_STDSTRING
+}
+
+// Issue 226: Value of string type should not point to NULL
+TEST(Value, SetStringNullException) {
+    Value v;
+    EXPECT_THROW(v.SetString(0, 0), AssertException);
 }
 
 TEST(Value, Array) {


### PR DESCRIPTION
1. Fixes `Value(kStringType)` by using short string to store `""` instead of null pointer.
2. Tests `SetString(0, 0)` assertion fail.
3. Assertion on member name in `Accept()`.

Closes #226 