### PR TITLE
Use aligned SSE register load intrinsic.

### DIFF
--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -277,7 +277,7 @@ inline const char *SkipWhitespace_SIMD(const char* p) {
 
     // The rest of string using SIMD
 	static const char whitespace[16] = " \n\r\t";
-	const __m128i w = _mm_loadu_si128((const __m128i *)&whitespace[0]);
+	const __m128i w = _mm_load_si128((const __m128i *)&whitespace[0]);
 
     for (;; p += 16) {
         const __m128i s = _mm_load_si128((const __m128i *)p);


### PR DESCRIPTION
The code immediately before this changed line goes to the trouble of ensuring that data is aligned at a 16-byte boundary, then goes ahead and uses the unaligned form of the load intrinsic `_mm_loadu_si128`.

Either the code shouldn't bother aligning the data to the start of the whitespace, or it should use the aligned form of the intrinsic.

It's possible that on real-world JSON, better performance is observed by avoiding the serial walk to the boundary and instead using the unaligned load directly. There's no hard _requirement_ to have data aligned here, as far as I know. Was this tested?