### PR TITLE
Add std::string overload to Writer when RAPIDJSON_HAS_STDSTRING defined

### DIFF
--- a/example/serialize/serialize.cpp
+++ b/example/serialize/serialize.cpp
@@ -19,7 +19,7 @@ protected:
     void Serialize(Writer& writer) const {
         // This base class just write out name-value pairs, without wrapping within an object.
         writer.String("name");
-        writer.String(name_.c_str(), (SizeType)name_.length()); // Suppling length of string is faster.
+        writer.String(name_.c_str(), (SizeType)name_.length()); // Supplying length of string is faster.
 
         writer.String("age");
         writer.Uint(age_);

--- a/example/serialize/serialize.cpp
+++ b/example/serialize/serialize.cpp
@@ -19,8 +19,11 @@ protected:
     void Serialize(Writer& writer) const {
         // This base class just write out name-value pairs, without wrapping within an object.
         writer.String("name");
+#ifdef RAPIDJSON_HAS_STDSTRING
+        writer.String(name_);
+#else
         writer.String(name_.c_str(), (SizeType)name_.length()); // Supplying length of string is faster.
-
+#endif
         writer.String("age");
         writer.Uint(age_);
     }
@@ -42,7 +45,11 @@ public:
         writer.StartObject();
         
         writer.String("school");
+#ifdef RAPIDJSON_HAS_STDSTRING
+        writer.String(school_);
+#else
         writer.String(school_.c_str(), (SizeType)school_.length());
+#endif
 
         writer.String("GPA");
         writer.Double(GPA_);

--- a/include/rapidjson/prettywriter.h
+++ b/include/rapidjson/prettywriter.h
@@ -82,6 +82,12 @@ public:
         return Base::WriteString(str, length);
     }
 
+#if RAPIDJSON_HAS_STDSTRING
+    bool String(const std::basic_string<Ch>& str) {
+      return String(str.data(), SizeType(str.size()));
+    }
+#endif
+
     bool StartObject() {
         PrettyPrefix(kObjectType);
         new (Base::level_stack_.template Push<typename Base::Level>()) typename Base::Level(false);

--- a/include/rapidjson/writer.h
+++ b/include/rapidjson/writer.h
@@ -29,6 +29,10 @@
 #include "stringbuffer.h"
 #include <new>      // placement new
 
+#if RAPIDJSON_HAS_STDSTRING
+#include <string>
+#endif
+
 #ifdef _MSC_VER
 RAPIDJSON_DIAG_PUSH
 RAPIDJSON_DIAG_OFF(4127) // conditional expression is constant

--- a/include/rapidjson/writer.h
+++ b/include/rapidjson/writer.h
@@ -127,6 +127,12 @@ public:
         return WriteString(str, length);
     }
 
+#if RAPIDJSON_HAS_STDSTRING
+    bool String(const std::basic_string<Ch>& str) {
+      return String(str.data(), SizeType(str.size()));
+    }
+#endif
+
     bool StartObject() {
         Prefix(kObjectType);
         new (level_stack_.template Push<Level>()) Level(false);


### PR DESCRIPTION
Currently `RAPIDJSON_HAS_STDSTRING` is only used in `document.h`. It is also useful in `Writer::String` and `PrettyWriter::String`