### PR TITLE
Compilation fixes

### DIFF
--- a/include/rapidjson/internal/biginteger.h
+++ b/include/rapidjson/internal/biginteger.h
@@ -172,7 +172,7 @@ public:
         };
         if (exp == 0) return *this;
         for (; exp >= 27; exp -= 27) *this *= RAPIDJSON_UINT64_C2(0X6765C793, 0XFA10079D); // 5^27
-        for (; exp >= 13; exp -= 13) *this *= 1220703125u; // 5^13
+        for (; exp >= 13; exp -= 13) *this *= static_cast<uint32_t>(1220703125u); // 5^13
         if (exp > 0)                 *this *= kPow5[exp - 1];
         return *this;
     }

--- a/include/rapidjson/internal/biginteger.h
+++ b/include/rapidjson/internal/biginteger.h
@@ -148,7 +148,7 @@ public:
     }
 
     bool operator==(const BigInteger& rhs) const {
-        return count_ == rhs.count_ && memcmp(digits_, rhs.digits_, count_ * sizeof(Type)) == 0;
+        return count_ == rhs.count_ && std::memcmp(digits_, rhs.digits_, count_ * sizeof(Type)) == 0;
     }
 
     bool operator==(const Type rhs) const {


### PR DESCRIPTION
Fixes compilation issues with some less common configurations:
- compiler that does not import c stdlib functions into global namespace when including through c++ headers (cstring vs string.h)
- platform with uint32_t typedefed to 32-bit unsigned long and uint64_t to 64-bit unsigned long long - compiler cannot decide between overloads when using unsigned int literal