### PR TITLE
add AppVeyor CI support for checked Windows builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,9 +54,9 @@ endif()
 
 if(RAPIDJSON_BUILD_TESTS)
     if(MSVC11)
-	    # required for VS2012 due to missing support for variadic templates
-	    add_definitions(-D_VARIADIC_MAX=10)
-	endif(MSVC11)
+        # required for VS2012 due to missing support for variadic templates
+        add_definitions(-D_VARIADIC_MAX=10)
+    endif(MSVC11)
     add_subdirectory(test)
     include(CTest)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,10 @@ if(RAPIDJSON_BUILD_EXAMPLES)
 endif()
 
 if(RAPIDJSON_BUILD_TESTS)
+    if(MSVC11)
+	    # required for VS2012 due to missing support for variadic templates
+	    add_definitions(-D_VARIADIC_MAX=10)
+	endif(MSVC11)
     add_subdirectory(test)
     include(CTest)
 endif()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,4 +25,4 @@ build:
   verbosity: minimal
 
 test_script:
-- cd Build\VS && ctest --verbose --timeout 120 --build-config %CONFIGURATION%
+- cd Build\VS && ctest --verbose --build-config %CONFIGURATION%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-ersion: 0.12.{build}
+version: 0.12.{build}
 
 configuration:
 - Debug

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,23 +1,23 @@
-version: 0.12.{build}
+ersion: 0.12.{build}
 
 configuration:
 - Debug
 - Release
 
-platform:
-- x86
-- x64
-
 environment:
   matrix:
   - VS_VERSION: 11
+    VS_PLATFORM: win32
+  - VS_VERSION: 11
+    VS_PLATFORM: x64
   - VS_VERSION: 12
-  - VS_VERSION: 14
-
+    VS_PLATFORM: win32
+  - VS_VERSION: 12
+    VS_PLATFORM: x64
+	
 before_build:
 - git submodule update --init --recursive
-- if "%PLATFORM%" == "x86" set PLATFORM=win32
-- cmake -H. -BBuild/VS -G "Visual Studio %VS_VERSION%" -DCMAKE_GENERATOR_PLATFORM=%PLATFORM% -DBUILD_SHARED_LIBS=true -Wno-dev
+- cmake -H. -BBuild/VS -G "Visual Studio %VS_VERSION%" -DCMAKE_GENERATOR_PLATFORM=%VS_PLATFORM% -DBUILD_SHARED_LIBS=true -Wno-dev
 
 build:
   project: Build\VS\RapidJSON.sln

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,28 @@
+version: 0.12.{build}
+
+configuration:
+- Debug
+- Release
+
+platform:
+- x86
+- x64
+
+environment:
+  matrix:
+  - VS_VERSION: 11
+  - VS_VERSION: 12
+  - VS_VERSION: 14
+
+before_build:
+- git submodule update --init --recursive
+- if "%PLATFORM%" == "x86" set PLATFORM=win32
+- cmake -H. -BBuild/VS -G "Visual Studio %VS_VERSION%" -DCMAKE_GENERATOR_PLATFORM=%PLATFORM% -DBUILD_SHARED_LIBS=true -Wno-dev
+
+build:
+  project: Build\VS\RapidJSON.sln
+  parallel: true
+  verbosity: minimal
+
+test_script:
+- cd Build\VS && ctest --verbose --timeout 120 --build-config %CONFIGURATION%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ environment:
     VS_PLATFORM: win32
   - VS_VERSION: 12
     VS_PLATFORM: x64
-	
+
 before_build:
 - git submodule update --init --recursive
 - cmake -H. -BBuild/VS -G "Visual Studio %VS_VERSION%" -DCMAKE_GENERATOR_PLATFORM=%VS_PLATFORM% -DBUILD_SHARED_LIBS=true -Wno-dev

--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ RapidJSON is a header-only C++ library. Just copy the `include/rapidjson` folder
 
 RapidJSON uses following software as its dependencies:
 * [CMake](http://www.cmake.org) as a general build tool
-* (optional)[Doxygen](http://www.goxygen.org) to build documentation
+* (optional)[Doxygen](http://www.doxygen.org) to build documentation
 * (optional)[googletest](https://code.google.com/p/googletest/) for unit and performance testing
 
 To generate user documentation and run tests please proceed with the steps below:

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ Copyright (c) 2011-2014 Milo Yip (miloyip@gmail.com)
 [RapidJSON Documentation](http://miloyip.github.io/rapidjson/)
 
 ## Build status
-* Tavis CI (Linux): [![Travis Build status](https://travis-ci.org/Kosta-Github/rapidjson)](https://travis-ci.org/Kosta-Github/rapidjson)
+* Tavis CI (Linux): [![Travis Build status](https://travis-ci.org/miloyip/rapidjson)](https://travis-ci.org/miloyip/rapidjson)
 * AppVeyor (Windows): [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/3xw2isxomp5r4do7/branch/master?svg=true)](https://ci.appveyor.com/project/Kosta-Github/rapidjson/branch/master)
 
 ## Introduction

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ Copyright (c) 2011-2014 Milo Yip (miloyip@gmail.com)
 [RapidJSON Documentation](http://miloyip.github.io/rapidjson/)
 
 ## Build status
-* Tavis CI (Linux): [![Travis Build status](https://travis-ci.org/miloyip/rapidjson)](https://travis-ci.org/miloyip/rapidjson)
+* Tavis CI (Linux): [![Travis Build status](https://travis-ci.org/miloyip/rapidjson.png)](https://travis-ci.org/miloyip/rapidjson)
 * AppVeyor (Windows): [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/3xw2isxomp5r4do7/branch/master?svg=true)](https://ci.appveyor.com/project/Kosta-Github/rapidjson/branch/master)
 
 ## Introduction

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,10 @@ Copyright (c) 2011-2014 Milo Yip (miloyip@gmail.com)
 
 [RapidJSON Documentation](http://miloyip.github.io/rapidjson/)
 
+## Build status
+* Tavis CI (Linux): [![Travis Build status](https://travis-ci.org/Kosta-Github/rapidjson)](https://travis-ci.org/Kosta-Github/rapidjson)
+* AppVeyor (Windows): [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/3xw2isxomp5r4do7/branch/master?svg=true)](https://ci.appveyor.com/project/Kosta-Github/rapidjson/branch/master)
+
 ## Introduction
 
 RapidJSON is a JSON parser and generator for C++. It was inspired by [RapidXml](http://rapidxml.sourceforge.net/).

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -21,12 +21,15 @@ add_test(NAME unittest
     COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/bin)
 
-add_test(NAME valgrind_unittest
-    COMMAND valgrind --leak-check=full --error-exitcode=1 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/bin)
+if(NOT MSVC)
+    add_test(NAME valgrind_unittest
+        COMMAND valgrind --leak-check=full --error-exitcode=1 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/bin)
 
-IF((NOT MSVC) AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
-add_test(NAME symbol_check
-    COMMAND sh -c "objdump -t -C libnamespacetest.a | grep rapidjson ; test $? -ne 0"
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-ENDIF()
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+        add_test(NAME symbol_check
+        COMMAND sh -c "objdump -t -C libnamespacetest.a | grep rapidjson ; test $? -ne 0"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+    endif(CMAKE_BUILD_TYPE STREQUAL "Debug")
+
+endif(NOT MSVC)

--- a/test/unittest/documenttest.cpp
+++ b/test/unittest/documenttest.cpp
@@ -253,8 +253,8 @@ TEST(Document, Traits) {
 
     static_assert(!std::is_nothrow_constructible<Document>::value, "");
     static_assert(!std::is_nothrow_default_constructible<Document>::value, "");
-    static_assert(!std::is_nothrow_copy_constructible<Document>::value, "");
 #ifndef _MSC_VER
+    static_assert(!std::is_nothrow_copy_constructible<Document>::value, "");
     static_assert(std::is_nothrow_move_constructible<Document>::value, "");
 #endif
 

--- a/test/unittest/valuetest.cpp
+++ b/test/unittest/valuetest.cpp
@@ -54,9 +54,7 @@ TEST(Value, Traits) {
 #ifndef _MSC_VER
     static_assert(std::is_nothrow_constructible<Value>::value, "");
     static_assert(std::is_nothrow_default_constructible<Value>::value, "");
-#endif
     static_assert(!std::is_nothrow_copy_constructible<Value>::value, "");
-#ifndef _MSC_VER
     static_assert(std::is_nothrow_move_constructible<Value>::value, "");
 #endif
 


### PR DESCRIPTION
[`AppVeyor`](http://appveyor.com) provides a free service for doing checked Windows builds (similar to [`Travis CI`](https://travis-ci.org) for Linux).

The following [build matrix](https://ci.appveyor.com/project/Kosta-Github/rapidjson/history) has been created for my account:
  - `VS2012`, `VS2013`
  - `win32`, `x64`
  - `Debug`, `Release`

Steps to integrate this into your repo:
  1. Sign in into http://appveyor.com with your github account
  2. Add your `rapidjson` project to your `AppVeyor` project list
  3. Switch to your project setting: https://ci.appveyor.com/project/miloyip/rapidjson/settings
  4. Check `Skip branches without appveyor.yml` and press the `Save` button
  5. Replace the `badge` link in `readme.md` with a link pointing to your `AppVeyor` account by using the `badge` link from this page: https://ci.appveyor.com/project/miloyip/rapidjson/settings/badges
  6. Done.