### PR TITLE
error.h: drop trailing comma in enum

### DIFF
--- a/include/rapidjson/error/error.h
+++ b/include/rapidjson/error/error.h
@@ -85,7 +85,7 @@ enum ParseErrorCode {
     kParseErrorNumberMissExponent,              //!< Miss exponent in number.
 
     kParseErrorTermination,                     //!< Parsing was terminated.
-    kParseErrorUnspecificSyntaxError,           //!< Unspecific syntax error.
+    kParseErrorUnspecificSyntaxError            //!< Unspecific syntax error.
 };
 
 //! Result of parsing (wraps ParseErrorCode)


### PR DESCRIPTION
In C++'98/03, trailing commas in enumerations are not allowed, but have been introduced in C++11. This patch drops the trailing commas in order to avoid compiler warnings (e.g. GCC with `-pedantic`).

See #9 and http://code.google.com/p/rapidjson/issues/detail?id=49 for previous instances of this issue.