### PR TITLE
RapidJSON.pc.in: include dir not set

### DIFF
--- a/RapidJSON.pc.in
+++ b/RapidJSON.pc.in
@@ -1,4 +1,7 @@
+includedir=@INCLUDE_INSTALL_DIR@
+
 Name: @PROJECT_NAME@
-Description: RapidJSON is a JSON parser and generator for C++ inspired by RapidXml.
+Description: A fast JSON parser/generator for C++ with both SAX/DOM style API
 Version: @LIB_VERSION_STRING@
+URL: https://github.com/miloyip/rapidjson
 Cflags: -I${includedir}


### PR DESCRIPTION
Variable in wrong format is not replaced