### PR TITLE
GenericValue::AddMember<T>: add missing overload (closes #254)

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -954,6 +954,44 @@ public:
         return *this;
     }
 
+    //! Add a constant string value as member (name-value pair) to the object.
+    /*! \param name A string value as name of member.
+        \param value constant string reference as value of member.
+        \param allocator    Allocator for reallocating memory. It must be the same one as used before. Commonly use GenericDocument::GetAllocator().
+        \return The value itself for fluent API.
+        \pre  IsObject()
+        \note This overload is needed to avoid clashes with the generic primitive type AddMember(GenericValue&,T,Allocator&) overload below.
+        \note Amortized Constant time complexity.
+    */
+    GenericValue& AddMember(GenericValue& name, StringRefType value, Allocator& allocator) {
+        GenericValue v(value);
+        return AddMember(name, v, allocator);
+    }
+
+    //! Add any primitive value as member (name-value pair) to the object.
+    /*! \tparam T Either \ref Type, \c int, \c unsigned, \c int64_t, \c uint64_t
+        \param name A string value as name of member.
+        \param value Value of primitive type \c T as value of member
+        \param allocator Allocator for reallocating memory. Commonly use GenericDocument::GetAllocator().
+        \return The value itself for fluent API.
+        \pre  IsObject()
+
+        \note The source type \c T explicitly disallows all pointer types,
+            especially (\c const) \ref Ch*.  This helps avoiding implicitly
+            referencing character strings with insufficient lifetime, use
+            \ref AddMember(StringRefType, GenericValue&, Allocator&) or \ref
+            AddMember(StringRefType, StringRefType, Allocator&).
+            All other pointer types would implicitly convert to \c bool,
+            use an explicit cast instead, if needed.
+        \note Amortized Constant time complexity.
+    */
+    template <typename T>
+    RAPIDJSON_DISABLEIF_RETURN((internal::OrExpr<internal::IsPointer<T>, internal::IsGenericValue<T> >), (GenericValue&))
+    AddMember(GenericValue& name, T value, Allocator& allocator) {
+        GenericValue v(value);
+        return AddMember(name, v, allocator);
+    }
+
 #if RAPIDJSON_HAS_CXX11_RVALUE_REFS
     GenericValue& AddMember(GenericValue&& name, GenericValue&& value, Allocator& allocator) {
         return AddMember(name, value, allocator);
@@ -1021,8 +1059,7 @@ public:
     RAPIDJSON_DISABLEIF_RETURN((internal::OrExpr<internal::IsPointer<T>, internal::IsGenericValue<T> >), (GenericValue&))
     AddMember(StringRefType name, T value, Allocator& allocator) {
         GenericValue n(name);
-        GenericValue v(value);
-        return AddMember(n, v, allocator);
+        return AddMember(n, value, allocator);
     }
 
     //! Remove all members in the object.

--- a/test/unittest/valuetest.cpp
+++ b/test/unittest/valuetest.cpp
@@ -919,6 +919,19 @@ TEST(Value, Object) {
         EXPECT_EQ(8u, o.MemberCount());
     }
 
+    // AddMember<T>(Value&, T, Allocator)
+    {
+        Value o(kObjectType);
+
+        Value n("s");
+        o.AddMember(n, "string", allocator);
+        EXPECT_EQ(1u, o.MemberCount());
+
+        Value count("#");
+        o.AddMember(count, o.MemberCount(), allocator);
+        EXPECT_EQ(2u, o.MemberCount());
+    }
+
 #if RAPIDJSON_HAS_CXX11_RVALUE_REFS
     // AddMember(GenericValue&&, ...) variants
     {


### PR DESCRIPTION
As discovered by @felipegb94, there are missing overloads to the `GenericValue::AddMember<T>` template function, taking an explicit `GenericValue&` as a name and accepting arbitrary primitive values.

This patch adds the missing overloads. The `StringRefType` overload is needed to disambiguate the addition of a string literal as value.

Some tests are added to `TEST(Value, Object)` in `valuetest.cpp`.