### PR TITLE
Skip running perftest on CI debug builds (Appveyer; Travis)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,10 @@
 !/bin/data
 !/bin/encodings
 !/bin/jsonchecker
+/build
 /doc/html
 /doc/doxygen_*.db
-/thirdparty/lib
-/intermediate
+*.a
 
 # Temporary files created during CMake build
 CMakeCache.txt
@@ -20,4 +20,3 @@ Testing
 install_manifest.txt
 Doxyfile
 DartConfiguration.tcl
-/build/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
     - secure: "HrsaCb+N66EG1HR+LWH1u51SjaJyRwJEDzqJGYMB7LJ/bfqb9mWKF1fLvZGk46W5t7TVaXRDD5KHFx9DPWvKn4gRUVkwTHEy262ah5ORh8M6n/6VVVajeV/AYt2C0sswdkDBDO4Xq+xy5gdw3G8s1A4Inbm73pUh+6vx+7ltBbk="
 
 before_install:
+  - sudo apt-get update -qq
   - sudo apt-get install -qq cmake doxygen valgrind
   - if [ "$ARCH" = "x86" ]; then sudo apt-get install -qq g++-multilib libc6-dbg:i386; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,13 @@ compiler:
 
 env:
   matrix:
-    - CONF=debug ARCH=x86_64 ARCH_FLAGS=""
-    - CONF=release ARCH=x86_64 ARCH_FLAGS=""
-    - CONF=debug ARCH=x86 ARCH_FLAGS="-m32"
-    - CONF=release ARCH=x86 ARCH_FLAGS="-m32"
+    - CONF=debug   ARCH=x86_64
+    - CONF=release ARCH=x86_64
+    - CONF=debug   ARCH=x86
+    - CONF=release ARCH=x86
   global:
+    - ARCH_FLAGS_x86='-m32'
+    - ARCH_FLAGS_x86_64=''
     - GITHUB_REPO='miloyip/rapidjson'
     - secure: "HrsaCb+N66EG1HR+LWH1u51SjaJyRwJEDzqJGYMB7LJ/bfqb9mWKF1fLvZGk46W5t7TVaXRDD5KHFx9DPWvKn4gRUVkwTHEy262ah5ORh8M6n/6VVVajeV/AYt2C0sswdkDBDO4Xq+xy5gdw3G8s1A4Inbm73pUh+6vx+7ltBbk="
 
@@ -24,6 +26,7 @@ before_script:
     - sed -i 's/march=native/msse4.2/' CMakeLists.txt
     - mkdir build 
     - >
+        eval "ARCH_FLAGS=\${ARCH_FLAGS_${ARCH}}"
         (cd build && cmake 
         -DRAPIDJSON_HAS_STDSTRING=ON
         -DCMAKE_VERBOSE_MAKEFILE=ON 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_script:
         -DRAPIDJSON_HAS_STDSTRING=ON
         -DCMAKE_VERBOSE_MAKEFILE=ON 
         -DCMAKE_BUILD_TYPE=$CONF 
-        -DCMAKE_C_FLAGS="$ARCH_FLAGS" ..)
+        -DCMAKE_CXX_FLAGS="$ARCH_FLAGS" ..)
 
 script:
   - cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,5 +39,5 @@ script:
   - cd build
   - make tests
   - make examples
-  - ctest -V
+  - ctest -V `[ "$CONF" = "release" ] || echo "-E perftest"`
   - make travis_doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_script:
     - sed -i 's/march=native/msse4.2/' CMakeLists.txt
     - mkdir build 
     - >
-        eval "ARCH_FLAGS=\${ARCH_FLAGS_${ARCH}}"
+        eval "ARCH_FLAGS=\${ARCH_FLAGS_${ARCH}}" ;
         (cd build && cmake 
         -DRAPIDJSON_HAS_STDSTRING=ON
         -DCMAKE_VERBOSE_MAKEFILE=ON 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
 install: true
 
 before_script:
+    - sed -i 's/march=native/msse4.2/' CMakeLists.txt
     - mkdir build 
     - >
         (cd build && cmake 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ before_install:
 install: true
 
 before_script:
+#   hack to avoid Valgrind bug (https://bugs.kde.org/show_bug.cgi?id=326469),
+#   exposed by merging PR#163 (using -march=native)
     - sed -i 's/march=native/msse4.2/' CMakeLists.txt
     - mkdir build 
     - >
@@ -32,9 +34,6 @@ before_script:
         -DCMAKE_VERBOSE_MAKEFILE=ON 
         -DCMAKE_BUILD_TYPE=$CONF 
         -DCMAKE_C_FLAGS="$ARCH_FLAGS" ..)
-#   hack to avoid Valgrind bug (https://bugs.kde.org/show_bug.cgi?id=326469),
-#   exposed by merging PR#163 (using -march=native)
-#  - (cd build/gmake && sed -i 's/march=native/msse4.2/' *.make)
 
 script:
   - cd build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,13 @@ if(RAPIDJSON_HAS_STDSTRING)
     add_definitions(-DRAPIDJSON_HAS_STDSTRING)
 endif()
 
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -Wall -Wextra")
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -Wall -Wextra")
+elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS=1)
+endif()
 
 #add extra search paths for libraries and includes
 SET(INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/include" CACHE PATH "The directory the headers are installed in")
@@ -36,9 +43,7 @@ ELSEIF(WIN32)
 ENDIF()
 SET(CMAKE_INSTALL_DIR "${_CMAKE_INSTALL_DIR}" CACHE PATH "The directory cmake fiels are installed in")
 
-
 include_directories(${CMAKE_SOURCE_DIR}/include)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${RAPIDJSON_CXX_FLAGS}")
 
 if(RAPIDJSON_BUILD_DOC)
     add_subdirectory(doc)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,4 +25,4 @@ build:
   verbosity: minimal
 
 test_script:
-- cd Build\VS && ctest --verbose --build-config %CONFIGURATION%
+- cd Build\VS && if %CONFIGURATION%==Debug (ctest --verbose -E perftest --build-config %CONFIGURATION%) else (ctest --verbose --build-config %CONFIGURATION%)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -14,6 +14,14 @@ set(EXAMPLES
     simplewriter
     tutorial)
 
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall -Wextra -Weffc++ -Wswitch-default")
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall -Wextra -Weffc++ -Wswitch-default")
+elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS=1)
+endif()
+
 foreach (example ${EXAMPLES})
     add_executable(${example} ${example}/${example}.cpp)
 endforeach()

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -1,14 +1,25 @@
 set(UNITTEST_SOURCES
+    bigintegertest.cpp
     documenttest.cpp
     encodedstreamtest.cpp
     encodingstest.cpp
     filestreamtest.cpp
     jsoncheckertest.cpp
+    namespacetest.cpp
     readertest.cpp
+    stringbuffertest.cpp
+    strtodtest.cpp
     unittest.cpp
-    unittest.h
     valuetest.cpp
     writertest.cpp)
+
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Weffc++ -Wswitch-default")
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Weffc++ -Wswitch-default")
+elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS=1)
+endif()
 
 add_library(namespacetest STATIC namespacetest.cpp)
 


### PR DESCRIPTION
The runtimes for the CI builds on Appveyor and Travis CI are currently horribly long.  The main reason for this is the inclusion of the `perftest` even under Debug configurations.  This has not been the case before the cmake migration (#192).

This pull-request excludes `perftest` from the CI configurations `appveyor.yml` and `.travis.yml`.

To avoid merge conflicts, I've merged the pending pull-request #244 (which fixes #240) into this pull-request already. Let's see, what the current status of these pending changes is. ;-)