### PR TITLE
document.h: include <string>, iff RAPIDJSON_HAS_STDSTRING==1

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -55,6 +55,9 @@ RAPIDJSON_DIAG_OFF(effc++)
 
     \hideinitializer
 */
+#endif // !defined(RAPIDJSON_HAS_STDSTRING)
+
+#if RAPIDJSON_HAS_STDSTRING
 #include <string>
 #endif // RAPIDJSON_HAS_STDSTRING
 


### PR DESCRIPTION
As reported by @yachoor in https://github.com/miloyip/rapidjson/commit/c1c9ba7c#commitcomment-10434694, the `<string>` header has not been correctly included when `RAPIDJSON_HAS_STDSTRING` is defined by the user.