### PR TITLE
tutorial.cpp: fix insitu parsing (closes #273)

### DIFF
--- a/example/tutorial/tutorial.cpp
+++ b/example/tutorial/tutorial.cpp
@@ -24,12 +24,10 @@ int main(int, char*[]) {
         return 1;
 #else
     // In-situ parsing, decode strings directly in the source string. Source must be string.
-    {
-        char buffer[sizeof(json)];
-        memcpy(buffer, json, sizeof(json));
-        if (document.ParseInsitu(buffer).HasParseError())
-            return 1;
-    }
+    char buffer[sizeof(json)];
+    memcpy(buffer, json, sizeof(json));
+    if (document.ParseInsitu(buffer).HasParseError())
+        return 1;
 #endif
 
     printf("\nParsing to document succeeded.\n");


### PR DESCRIPTION
The insitu parsing example in the tutorial is using a local `char` buffer inside a nested scope.  After leaving the scope, the resulting `Document` object still references this (now invalidated)
memory locations.

Some compilers reuse this space on the stack for other local variables later in the function, corrupting the original document. 

Drop the local scope to extend the lifetime of the buffer, which fixes #273.