### PR TITLE
Fixes for GCC with -pedantic

### DIFF
--- a/example/messagereader/messagereader.cpp
+++ b/example/messagereader/messagereader.cpp
@@ -54,7 +54,7 @@ struct MessageHandler
     enum State {
         kExpectObjectStart,
         kExpectNameOrObjectEnd,
-        kExpectValue,
+        kExpectValue
     }state_;
     std::string name_;
 };

--- a/include/rapidjson/encodings.h
+++ b/include/rapidjson/encodings.h
@@ -30,6 +30,7 @@ RAPIDJSON_DIAG_OFF(4702)  // unreachable code
 #elif defined(__GNUC__)
 RAPIDJSON_DIAG_PUSH
 RAPIDJSON_DIAG_OFF(effc++)
+RAPIDJSON_DIAG_OFF(overflow)
 #endif
 
 RAPIDJSON_NAMESPACE_BEGIN

--- a/include/rapidjson/internal/biginteger.h
+++ b/include/rapidjson/internal/biginteger.h
@@ -252,7 +252,8 @@ private:
             (*outHigh)++;
         return low;
 #elif (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) && defined(__x86_64__)
-        unsigned __int128 p = static_cast<unsigned __int128>(a) * static_cast<unsigned __int128>(b);
+        __extension__ typedef unsigned __int128 uint128;
+        uint128 p = static_cast<uint128>(a) * static_cast<uint128>(b);
         p += k;
         *outHigh = p >> 64;
         return static_cast<uint64_t>(p);

--- a/include/rapidjson/internal/diyfp.h
+++ b/include/rapidjson/internal/diyfp.h
@@ -75,7 +75,8 @@ struct DiyFp {
             h++;
         return DiyFp(h, e + rhs.e + 64);
 #elif (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) && defined(__x86_64__)
-        unsigned __int128 p = static_cast<unsigned __int128>(f) * static_cast<unsigned __int128>(rhs.f);
+        __extension__ typedef unsigned __int128 uint128;
+        uint128 p = static_cast<uint128>(f) * static_cast<uint128>(rhs.f);
         uint64_t h = p >> 64;
         uint64_t l = static_cast<uint64_t>(p);
         if (l & (uint64_t(1) << 63)) // rounding


### PR DESCRIPTION
When compiling with `-pedantic`, some additional warnings are reported by GCC.

* Another trailing comma in an enum in `messagereader.cpp`
* The `unsigned __int128` type is an extension, add an attribute to mark it as such.
* Overflow warnings occur in `encodings.h` due to signedness of `char` on some platforms.  
  Hide those for now, as they are all false positives.

No functional changes (intended).