### PR TITLE
fix zh-cn Doxygen generation for Travis CI

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -8,11 +8,13 @@ ELSE()
     list(APPEND MARKDOWN_DOC ${CMAKE_SOURCE_DIR}/readme.md)
 
     CONFIGURE_FILE(Doxyfile.in Doxyfile @ONLY)
+    CONFIGURE_FILE(Doxyfile.zh-cn.in Doxyfile.zh-cn @ONLY)
 
     add_custom_command(OUTPUT html
         COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
+        COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile.zh-cn
         COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/html
-        DEPENDS ${MARKDOWN_DOC} ${SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
+        DEPENDS ${MARKDOWN_DOC} ${SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile*
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         )
 

--- a/doc/Doxyfile.zh-cn.in
+++ b/doc/Doxyfile.zh-cn.in
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = ./doc
+OUTPUT_DIRECTORY       = @CMAKE_CURRENT_BINARY_DIR@
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,12 @@
 ![](doc/logo/rapidjson.png)
 ## A fast JSON parser/generator for C++ with both SAX/DOM style API 
 
-Copyright (c) 2011-2014 Milo Yip (miloyip@gmail.com)
+Copyright (c) 2011-2015 Milo Yip (miloyip@gmail.com)
 
 * [RapidJSON GitHub](https://github.com/miloyip/rapidjson/)
 * [RapidJSON Documentation](http://miloyip.github.io/rapidjson/)
+  * [English](http://miloyip.github.io/rapidjson/)
+  * [Chinese](http://miloyip.github.io/rapidjson/zh-cn/)
 
 ## Build status
 

--- a/readme.zh-cn.md
+++ b/readme.zh-cn.md
@@ -1,10 +1,11 @@
 ![](doc/logo/rapidjson.png)
 
-Copyright (c) 2011-2014 Milo Yip (miloyip@gmail.com)
+Copyright (c) 2011-2015 Milo Yip (miloyip@gmail.com)
 
-[RapidJSON GitHub](https://github.com/miloyip/rapidjson/)
-
-[RapidJSON 文档](http://miloyip.github.io/rapidjson/)
+* [RapidJSON GitHub](https://github.com/miloyip/rapidjson/)
+* [RapidJSON 文档](http://miloyip.github.io/rapidjson/zh-cn/)
+  * [中国](http://miloyip.github.io/rapidjson/zh-cn/)
+  * [English](http://miloyip.github.io/rapidjson/)
 
 ## 简介
 

--- a/readme.zh-cn.md
+++ b/readme.zh-cn.md
@@ -5,7 +5,7 @@ Copyright (c) 2011-2015 Milo Yip (miloyip@gmail.com)
 * [RapidJSON GitHub](https://github.com/miloyip/rapidjson/)
 * [RapidJSON 文档](http://miloyip.github.io/rapidjson/zh-cn/)
   * [中国](http://miloyip.github.io/rapidjson/zh-cn/)
-  * [English](http://miloyip.github.io/rapidjson/)
+  * [英语](http://miloyip.github.io/rapidjson/)
 
 ## 简介
 


### PR DESCRIPTION
Just saw the failing build on Travis and fixed it. Please verify that I didn't mess up anything in Chinese. ;-)

* add creation of `Doxygen.zh-cn` to Cmake configuration
* build zh-cn documentation from Cmake as well
* add documentation cross-links to `readme*.md`