### PR TITLE
Fix #289 negative zero roundtrip (double only)

### DIFF
--- a/include/rapidjson/internal/dtoa.h
+++ b/include/rapidjson/internal/dtoa.h
@@ -21,6 +21,7 @@
 
 #include "itoa.h" // GetDigitsLut()
 #include "diyfp.h"
+#include "ieee754.h"
 
 RAPIDJSON_NAMESPACE_BEGIN
 namespace internal {
@@ -193,6 +194,9 @@ inline char* Prettify(char* buffer, int length, int k) {
 
 inline char* dtoa(double value, char* buffer) {
     if (value == 0) {
+        Double d(value);
+        if (d.Sign())
+            *buffer++ = '-';     // -0.0, Issue #289
         buffer[0] = '0';
         buffer[1] = '.';
         buffer[2] = '0';

--- a/test/unittest/readertest.cpp
+++ b/test/unittest/readertest.cpp
@@ -187,6 +187,8 @@ static void TestParseDouble() {
         Reader reader; \
         ASSERT_EQ(kParseErrorNone, reader.Parse<fullPrecision ? kParseFullPrecisionFlag : 0>(s, h).Code()); \
         EXPECT_EQ(1u, h.step_); \
+        internal::Double e(x), a(h.actual_); \
+        EXPECT_EQ(e.Sign(), a.Sign()); \
         if (fullPrecision) { \
             EXPECT_EQ(x, h.actual_); \
             if (x != h.actual_) \
@@ -197,6 +199,7 @@ static void TestParseDouble() {
     }
     
     TEST_DOUBLE(fullPrecision, "0.0", 0.0);
+    TEST_DOUBLE(fullPrecision, "-0.0", -0.0); // For checking issue #289
     TEST_DOUBLE(fullPrecision, "1.0", 1.0);
     TEST_DOUBLE(fullPrecision, "-1.0", -1.0);
     TEST_DOUBLE(fullPrecision, "1.5", 1.5);

--- a/test/unittest/writertest.cpp
+++ b/test/unittest/writertest.cpp
@@ -93,7 +93,7 @@ TEST(Writer, String) {
 
 TEST(Writer, Double) {
     TEST_ROUNDTRIP("[1.2345,1.2345678,0.123456789012,1234567.8]");
-
+    TEST_ROUNDTRIP("[-0.0]"); // Issue #289
 }
 
 TEST(Writer, Transcode) {


### PR DESCRIPTION
I have checked both `Reader` and `Writer`.
`Reader` is fine.
`Writer` drops the negative sign for `-0.0`.