### PR TITLE
fixed 'Unknown CMake command "find_package_handle_standard_args"'

### DIFF
--- a/CMakeModules/FindGTestSrc.cmake
+++ b/CMakeModules/FindGTestSrc.cmake
@@ -17,6 +17,7 @@ FIND_PATH(GTEST_INCLUDE_DIR
     PATH_SUFFIXES include
     PATHS ${GTEST_SEARCH_PATH})
 
+INCLUDE(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(GTestSrc DEFAULT_MSG
     GTEST_SOURCE_DIR
     GTEST_INCLUDE_DIR)


### PR DESCRIPTION
If one runs cmake with `cmake -DRAPIDJSON_BUILD_DOC=OFF`, it will fail with the following output:
```
CMake Error at CMakeModules/FindGTestSrc.cmake:20 (find_package_handle_standard_args):
  Unknown CMake command "find_package_handle_standard_args".
Call Stack (most recent call first):
  test/CMakeLists.txt:1 (find_package)
```

Thus INCLUDE(FindPackageHandleStandardArgs) is required before using find_package_handle_standard_args().