### PR TITLE
Improve code coverage for iterative parsing

### DIFF
--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -1273,12 +1273,9 @@ private:
                 return dst;
 
         case IterativeParsingKeyValueDelimiterState:
-            if (token == ColonToken) {
-                is.Take();
-                return dst;
-            }
-            else
-                return IterativeParsingErrorState;
+            RAPIDJSON_ASSERT(token == ColonToken);
+            is.Take();
+            return dst;
 
         case IterativeParsingMemberValueState:
             // Must be non-compound value. Or it would be ObjectInitial or ArrayInitial state.

--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -1227,6 +1227,8 @@ private:
     // May return a new state on state pop.
     template <unsigned parseFlags, typename InputStream, typename Handler>
     RAPIDJSON_FORCEINLINE IterativeParsingState Transit(IterativeParsingState src, Token token, IterativeParsingState dst, InputStream& is, Handler& handler) {
+        (void)token;
+
         switch (dst) {
         case IterativeParsingErrorState:
             return dst;

--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -1228,13 +1228,6 @@ private:
     template <unsigned parseFlags, typename InputStream, typename Handler>
     RAPIDJSON_FORCEINLINE IterativeParsingState Transit(IterativeParsingState src, Token token, IterativeParsingState dst, InputStream& is, Handler& handler) {
         switch (dst) {
-        case IterativeParsingStartState:
-            RAPIDJSON_ASSERT(false);
-            return IterativeParsingErrorState;
-
-        case IterativeParsingFinishState:
-            return dst;
-
         case IterativeParsingErrorState:
             return dst;
 
@@ -1350,17 +1343,25 @@ private:
             }
         }
 
-        case IterativeParsingValueState:
+        default:
+            // This branch is for IterativeParsingValueState actually.
+            // Use `default:` rather than
+            // `case IterativeParsingValueState:` is for code coverage.
+
+            // The IterativeParsingStartState is not enumerated in this switch-case.
+            // It is impossible for that case. And it can be caught by following assertion.
+
+            // The IterativeParsingFinishState is not enumerated in this switch-case either.
+            // It is a "derivative" state which cannot triggered from Predict() directly.
+            // Therefore it cannot happen here. And it can be caught by following assertion.
+            RAPIDJSON_ASSERT(dst == IterativeParsingValueState);
+
             // Must be non-compound value. Or it would be ObjectInitial or ArrayInitial state.
             ParseValue<parseFlags>(is, handler);
             if (HasParseError()) {
                 return IterativeParsingErrorState;
             }
             return IterativeParsingFinishState;
-
-        default:
-            RAPIDJSON_ASSERT(false);
-            return IterativeParsingErrorState;
         }
     }
 

--- a/test/unittest/readertest.cpp
+++ b/test/unittest/readertest.cpp
@@ -1051,6 +1051,7 @@ TEST(Reader, IterativeParsing_ErrorHandling) {
     TESTERRORHANDLING("false, false", kParseErrorDocumentRootNotSingular, 5u);
     TESTERRORHANDLING("nulL", kParseErrorValueInvalid, 3u);
     TESTERRORHANDLING("null , null", kParseErrorDocumentRootNotSingular, 5u);
+    TESTERRORHANDLING("1a", kParseErrorDocumentRootNotSingular, 1u);
 }
 
 template<typename Encoding = UTF8<> >

--- a/test/unittest/readertest.cpp
+++ b/test/unittest/readertest.cpp
@@ -1041,6 +1041,15 @@ TEST(Reader, IterativeParsing_ErrorHandling) {
     TESTERRORHANDLING("{\"a\"}", kParseErrorObjectMissColon, 4u);
     TESTERRORHANDLING("{\"a\": 1", kParseErrorObjectMissCommaOrCurlyBracket, 7u);
     TESTERRORHANDLING("[1 2 3]", kParseErrorArrayMissCommaOrSquareBracket, 3u);
+
+    // Any JSON value can be a valid root element in RFC7159.
+    TESTERRORHANDLING("\"ab", kParseErrorStringMissQuotationMark, 2u);
+    TESTERRORHANDLING("truE", kParseErrorValueInvalid, 3u);
+    TESTERRORHANDLING("False", kParseErrorValueInvalid, 0u);
+    TESTERRORHANDLING("true, false", kParseErrorDocumentRootNotSingular, 4u);
+    TESTERRORHANDLING("false, false", kParseErrorDocumentRootNotSingular, 5u);
+    TESTERRORHANDLING("nulL", kParseErrorValueInvalid, 3u);
+    TESTERRORHANDLING("null , null", kParseErrorDocumentRootNotSingular, 5u);
 }
 
 template<typename Encoding = UTF8<> >

--- a/test/unittest/readertest.cpp
+++ b/test/unittest/readertest.cpp
@@ -1041,6 +1041,7 @@ TEST(Reader, IterativeParsing_ErrorHandling) {
     TESTERRORHANDLING("{\"a\"}", kParseErrorObjectMissColon, 4u);
     TESTERRORHANDLING("{\"a\": 1", kParseErrorObjectMissCommaOrCurlyBracket, 7u);
     TESTERRORHANDLING("[1 2 3]", kParseErrorArrayMissCommaOrSquareBracket, 3u);
+    TESTERRORHANDLING("{\"a: 1", kParseErrorStringMissQuotationMark, 5u);
 
     // Any JSON value can be a valid root element in RFC7159.
     TESTERRORHANDLING("\"ab", kParseErrorStringMissQuotationMark, 2u);


### PR DESCRIPTION
* Supply unittests for parsing of JSON value as root element(RFC7159).
* Assert on impossible code paths.
* For switch-case in `Reader::Transit()` function,
put all impossible code cases and non-enumerated cases under `default:`(also with assertions).