### PR TITLE
Try to cover some functions by forcing them noinline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   - sudo apt-get install -qq cmake valgrind
   - sudo apt-get --no-install-recommends install doxygen # Don't install LaTeX stuffs
   - if [ "$ARCH" = "x86" ]; then sudo apt-get install -qq g++-multilib libc6-dbg:i386; fi
-  - if [ "$CC" = "gcc" ]; then sudo pip install cpp-coveralls; export GCOV_FLAGS='--coverage'; fi
+  - if [ "$CC" = "gcc" ]; then sudo pip install cpp-coveralls; export GCOV_FLAGS='--coverage -D RAPIDJSON_CODE_COVERAGE'; fi
 
 install: true
 

--- a/include/rapidjson/rapidjson.h
+++ b/include/rapidjson/rapidjson.h
@@ -118,6 +118,23 @@
 #endif // RAPIDJSON_NO_INT64TYPEDEF
 
 ///////////////////////////////////////////////////////////////////////////////
+// RAPIDJSON_FORCENOINLINE and RAPIDJSON_CODE_COVERAGE
+
+#ifndef RAPIDJSON_FORCENOINLINE
+#ifdef _MSC_VER
+#define RAPIDJSON_FORCENOINLINE __declspec(noinline)
+#elif defined(__GNUC__)
+#define RAPIDJSON_FORCENOINLINE __attribute__ ((noinline))
+#else
+#define RAPIDJSON_FORCENOINLINE 
+#endif
+#endif
+
+#ifdef RAPIDJSON_CODE_COVERAGE
+#define RAPIDJSON_FORCEINLINE RAPIDJSON_FORCENOINLINE
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
 // RAPIDJSON_FORCEINLINE
 
 #ifndef RAPIDJSON_FORCEINLINE


### PR DESCRIPTION
Some functions(`Reader::Tokenize`, `Reader::Predict` and `Transcoder::Transcode`)
are mistakenly reported uncovered.

This may be caused by inlining.

I try to resolve this by forcing noinline.