### PR TITLE
Fixed to build on older versions of 32-bit MSVC

### DIFF
--- a/include/rapidjson/internal/diyfp.h
+++ b/include/rapidjson/internal/diyfp.h
@@ -19,11 +19,9 @@
 #ifndef RAPIDJSON_DIYFP_H_
 #define RAPIDJSON_DIYFP_H_
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && defined(_M_AMD64)
 #include <intrin.h>
-#if defined(_M_AMD64)
 #pragma intrinsic(_BitScanReverse64)
-#endif
 #endif
 
 RAPIDJSON_NAMESPACE_BEGIN


### PR DESCRIPTION
Older versions have no intrin.h, but functions from intrin.h are not used if it's a 32-bit build.