### PR TITLE
Fix warnings when visited via https

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -28,7 +28,7 @@
 
 6. How to install RapidJSON?
 
-   Check [Installation section](http://miloyip.github.io/rapidjson/).
+   Check [Installation section](https://miloyip.github.io/rapidjson/).
 
 7. Can RapidJSON run on my platform?
 

--- a/doc/misc/footer.html
+++ b/doc/misc/footer.html
@@ -18,7 +18,7 @@
 	    (document.getElementsByClassName('contents')[0]).appendChild(dt);
 
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+        dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     })();
 </script>


### PR DESCRIPTION
Browser will show a warning when visiting https://miloyip.github.io/rapidjson/ :
> Mixed Content: The page at 'https://miloyip.github.io/rapidjson/' was loaded over HTTPS, but requested an insecure script 'http://rapidjson-doc.disqus.com/embed.js'. This request has been blocked; the content must be served over HTTPS.

This PR fixes this problem, and updates a link to use https. :smile: 