### PR TITLE
Fix alignment of 64bit platforms

### DIFF
--- a/include/rapidjson/rapidjson.h
+++ b/include/rapidjson/rapidjson.h
@@ -241,7 +241,11 @@
     alignment. User can customize by defining the RAPIDJSON_ALIGN function macro.,
 */
 #ifndef RAPIDJSON_ALIGN
+#if RAPIDJSON_64BIT == 1
+#define RAPIDJSON_ALIGN(x) ((x + 7u) & ~7u)
+#else
 #define RAPIDJSON_ALIGN(x) ((x + 3u) & ~3u)
+#endif
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
gcc 5 sanitizer was complaining about alignment on 64bit platform:

pbjson/rapidjson/document.h:1248:9: runtime error: member call on misaligned address 0x631000028b6c for type 'struct GenericValue', which requires 8 byte alignment
0x631000028b6c: note: pointer points here
  74 00 be be be be be be  be be be be be be be be  be be be be be be be be  be be be be be be be be