### PR TITLE
fix compile error when RAPIDJSON_HAS_STDSTRING=1

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -989,7 +989,7 @@ public:
     template <typename T>
     RAPIDJSON_DISABLEIF_RETURN((internal::OrExpr<internal::IsPointer<T>, internal::IsGenericValue<T> >), (GenericValue&))
     AddMember(GenericValue& name, T value, Allocator& allocator) {
-        GenericValue v(value);
+        GenericValue v(value, allocator);
         return AddMember(name, v, allocator);
     }
 


### PR DESCRIPTION
This fixes the following error when compiling with RAPIDJSON_HAS_STDSTRING=1.

./rapidjson/include/rapidjson/document.h:992:29: error: no matching function for call to ‘rapidjson::GenericValue<rapidjson::UTF8<> >::GenericValue(std::basic_string<char>&)’
./rapidjson/include/rapidjson/document.h:992:29: note: candidates are:
./rapidjson/include/rapidjson/document.h:554:5: note: rapidjson::GenericValue<Encoding, Allocator>::GenericValue(const std::basic_string<typename Encoding::Ch>&, Allocator&) [with Encoding = rapidjson::UTF8<>, Allocator = rapidjson::MemoryPoolAllocator<>, typename Encoding::Ch = char]
./rapidjson/include/rapidjson/document.h:554:5: note:   candidate expects 2 arguments, 1 provided
./rapidjson/include/rapidjson/document.h:548:5: note: rapidjson::GenericValue<Encoding, Allocator>::GenericValue(const Ch*, Allocator&) [with Encoding = rapidjson::UTF8<>, Allocator = rapidjson::MemoryPoolAllocator<>, rapidjson::GenericValue<Encoding, Allocator>::Ch = char]
./rapidjson/include/rapidjson/document.h:548:5: note:   candidate expects 2 arguments, 1 provided
./rapidjson/include/rapidjson/document.h:545:5: note: rapidjson::GenericValue<Encoding, Allocator>::GenericValue(const Ch*, rapidjson::SizeType, Allocator&) [with Encoding = rapidjson::UTF8<>, Allocator = rapidjson::MemoryPoolAllocator<>, rapidjson::GenericValue<Encoding, Allocator>::Ch = char, rapidjson::SizeType = unsigned int]
./rapidjson/include/rapidjson/document.h:545:5: note:   candidate expects 3 arguments, 1 provided
./rapidjson/include/rapidjson/document.h:542:14: note: rapidjson::GenericValue<Encoding, Allocator>::GenericValue(rapidjson::GenericValue<Encoding, Allocator>::StringRefType) [with Encoding = rapidjson::UTF8<>, Allocator = rapidjson::MemoryPoolAllocator<>, rapidjson::GenericValue<Encoding, Allocator>::StringRefType = rapidjson::GenericStringRef<char>, typename Encoding::Ch = char]
./rapidjson/include/rapidjson/document.h:542:14: note:   no known conversion for argument 1 from ‘std::basic_string<char>’ to ‘rapidjson::GenericStringRef<char>’
./rapidjson/include/rapidjson/document.h:539:5: note: rapidjson::GenericValue<Encoding, Allocator>::GenericValue(const Ch*, rapidjson::SizeType) [with Encoding = rapidjson::UTF8<>, Allocator = rapidjson::MemoryPoolAllocator<>, rapidjson::GenericValue<Encoding, Allocator>::Ch = char, rapidjson::SizeType = unsigned int]
./rapidjson/include/rapidjson/document.h:539:5: note:   candidate expects 2 arguments, 1 provided
./rapidjson/include/rapidjson/document.h:536:14: note: rapidjson::GenericValue<Encoding, Allocator>::GenericValue(double) [with Encoding = rapidjson::UTF8<>, Allocator = rapidjson::MemoryPoolAllocator<>]
./rapidjson/include/rapidjson/document.h:536:14: note:   no known conversion for argument 1 from ‘std::basic_string<char>’ to ‘double’
./rapidjson/include/rapidjson/document.h:525:14: note: rapidjson::GenericValue<Encoding, Allocator>::GenericValue(uint64_t) [with Encoding = rapidjson::UTF8<>, Allocator = rapidjson::MemoryPoolAllocator<>, uint64_t = long unsigned int]
./rapidjson/include/rapidjson/document.h:525:14: note:   no known conversion for argument 1 from ‘std::basic_string<char>’ to ‘long unsigned int’
./rapidjson/include/rapidjson/document.h:511:14: note: rapidjson::GenericValue<Encoding, Allocator>::GenericValue(int64_t) [with Encoding = rapidjson::UTF8<>, Allocator = rapidjson::MemoryPoolAllocator<>, int64_t = long int]
./rapidjson/include/rapidjson/document.h:511:14: note:   no known conversion for argument 1 from ‘std::basic_string<char>’ to ‘long int’
./rapidjson/include/rapidjson/document.h:504:14: note: rapidjson::GenericValue<Encoding, Allocator>::GenericValue(unsigned int) [with Encoding = rapidjson::UTF8<>, Allocator = rapidjson::MemoryPoolAllocator<>]
./rapidjson/include/rapidjson/document.h:504:14: note:   no known conversion for argument 1 from ‘std::basic_string<char>’ to ‘unsigned int’
./rapidjson/include/rapidjson/document.h:497:14: note: rapidjson::GenericValue<Encoding, Allocator>::GenericValue(int) [with Encoding = rapidjson::UTF8<>, Allocator = rapidjson::MemoryPoolAllocator<>]
./rapidjson/include/rapidjson/document.h:497:14: note:   no known conversion for argument 1 from ‘std::basic_string<char>’ to ‘int’
./rapidjson/include/rapidjson/document.h:487:14: note: template<class T> rapidjson::GenericValue::GenericValue(T, typename rapidjson::internal::EnableIf<typename rapidjson::internal::RemoveSfinaeTag<rapidjson::internal::SfinaeTag& (*)(rapidjson::internal::IsSame<T, bool>)>::Type>::Type*)
./rapidjson/include/rapidjson/document.h:477:5: note: template<class SourceAllocator> rapidjson::GenericValue::GenericValue(const rapidjson::GenericValue<Encoding, SourceAllocator>&, Allocator&)
./rapidjson/include/rapidjson/document.h:456:14: note: rapidjson::GenericValue<Encoding, Allocator>::GenericValue(rapidjson::Type) [with Encoding = rapidjson::UTF8<>, Allocator = rapidjson::MemoryPoolAllocator<>]
./rapidjson/include/rapidjson/document.h:456:14: note:   no known conversion for argument 1 from ‘std::basic_string<char>’ to ‘rapidjson::Type’
./rapidjson/include/rapidjson/document.h:447:5: note: rapidjson::GenericValue<Encoding, Allocator>::GenericValue(const rapidjson::GenericValue<Encoding, Allocator>&) [with Encoding = rapidjson::UTF8<>, Allocator = rapidjson::MemoryPoolAllocator<>, rapidjson::GenericValue<Encoding, Allocator> = rapidjson::GenericValue<rapidjson::UTF8<> >]
./rapidjson/include/rapidjson/document.h:447:5: note:   no known conversion for argument 1 from ‘std::basic_string<char>’ to ‘const rapidjson::GenericValue<rapidjson::UTF8<> >&’
./rapidjson/include/rapidjson/document.h:440:5: note: rapidjson::GenericValue<Encoding, Allocator>::GenericValue(rapidjson::GenericValue<Encoding, Allocator>&&) [with Encoding = rapidjson::UTF8<>, Allocator = rapidjson::MemoryPoolAllocator<>, rapidjson::GenericValue<Encoding, Allocator> = rapidjson::GenericValue<rapidjson::UTF8<> >]
./rapidjson/include/rapidjson/document.h:440:5: note:   no known conversion for argument 1 from ‘std::basic_string<char>’ to ‘rapidjson::GenericValue<rapidjson::UTF8<> >&&’
./rapidjson/include/rapidjson/document.h:436:5: note: rapidjson::GenericValue<Encoding, Allocator>::GenericValue() [with Encoding = rapidjson::UTF8<>, Allocator = rapidjson::MemoryPoolAllocator<>]
./rapidjson/include/rapidjson/document.h:436:5: note:   candidate expects 0 arguments, 1 provided