### PR TITLE
Fix CMakeLists for include as a thirdparty in projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
-SET(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/CMakeModules)
+SET(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules)
 
 PROJECT(RapidJSON CXX)
 
@@ -17,7 +17,7 @@ SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 option(RAPIDJSON_BUILD_DOC "Build rapidjson documentation." ON)
 option(RAPIDJSON_BUILD_EXAMPLES "Build rapidjson examples." ON)
 option(RAPIDJSON_BUILD_TESTS "Build rapidjson perftests and unittests." ON)
-option(RAPIDJSON_BUILD_THIRDPARTY_GTEST 
+option(RAPIDJSON_BUILD_THIRDPARTY_GTEST
     "Use gtest installation in `thirdparty/gtest` by default if available" OFF)
 
 option(RAPIDJSON_HAS_STDSTRING "" OFF)
@@ -45,7 +45,7 @@ ELSEIF(WIN32)
 ENDIF()
 SET(CMAKE_INSTALL_DIR "${_CMAKE_INSTALL_DIR}" CACHE PATH "The directory cmake fiels are installed in")
 
-include_directories(${CMAKE_SOURCE_DIR}/include)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 if(RAPIDJSON_BUILD_DOC)
     add_subdirectory(doc)

--- a/CMakeModules/FindGTestSrc.cmake
+++ b/CMakeModules/FindGTestSrc.cmake
@@ -1,7 +1,7 @@
 
-SET(GTEST_SEARCH_PATH 
+SET(GTEST_SEARCH_PATH
     "${GTEST_SOURCE_DIR}"
-    "${CMAKE_SOURCE_DIR}/thirdparty/gtest")
+    "${CMAKE_CURRENT_LIST_DIR}/../thirdparty/gtest")
 
 IF(UNIX)
     IF(RAPIDJSON_BUILD_THIRDPARTY_GTEST)
@@ -14,6 +14,7 @@ ENDIF()
 FIND_PATH(GTEST_SOURCE_DIR
     NAMES CMakeLists.txt src/gtest_main.cc
     PATHS ${GTEST_SEARCH_PATH})
+
 
 # Debian installs gtest include directory in /usr/include, thus need to look
 # for include directory separately from source directory.


### PR DESCRIPTION
This fix changes the `CMAKE_SOURCE_DIR` variable to relative variables so that rapidjson could be directly included as a submodule in a bigger project, using `add_subdirectory` CMake command.