### PR TITLE
Add a 'Reserve' method to the output stream concept

### DIFF
--- a/doc/stream.md
+++ b/doc/stream.md
@@ -254,6 +254,9 @@ concept Stream {
     //! \return Number of characters read from start.
     size_t Tell();
 
+    //! Prepare for writing 'size' characters.
+    void Reserve(size_t size);
+
     //! Begin writing operation at the current read pointer.
     //! \return The begin writer pointer.
     Ch* PutBegin();
@@ -272,7 +275,7 @@ concept Stream {
 ~~~~~~~~~~
 
 For input stream, they must implement `Peek()`, `Take()` and `Tell()`.
-For output stream, they must implement `Put()` and `Flush()`. 
+For output stream, they must implement `Reserve()`, `Put()` and `Flush()`. 
 There are two special interface, `PutBegin()` and `PutEnd()`, which are only for *in situ* parsing. Normal streams do not implement them. However, if the interface is not needed for a particular stream, it is still need to a dummy implementation, otherwise will generate compilation error.
 
 ## Example: istream wrapper {#ExampleIStreamWrapper}
@@ -300,6 +303,7 @@ public:
     size_t Tell() const { return (size_t)is_.tellg(); } // 3
 
     Ch* PutBegin() { assert(false); return 0; }
+    void Reserve(size_t) { assert(false); }
     void Put(Ch) { assert(false); }
     void Flush() { assert(false); }
     size_t PutEnd(Ch*) { assert(false); return 0; }
@@ -342,6 +346,7 @@ public:
     size_t Tell() const {  }
 
     Ch* PutBegin() { assert(false); return 0; }
+    void Reserve(size_t) { }
     void Put(Ch c) { os_.put(c); }                  // 1
     void Flush() { os_.flush(); }                   // 2
     size_t PutEnd(Ch*) { assert(false); return 0; }

--- a/include/rapidjson/encodedstream.h
+++ b/include/rapidjson/encodedstream.h
@@ -73,6 +73,7 @@ public:
             Encoding::PutBOM(os_);
     }
 
+    void Reserve(size_t size) { os_.Reserve(size); }
     void Put(Ch c) { Encoding::Put(os_, c);  }
     void Flush() { os_.Flush(); }
 
@@ -223,6 +224,7 @@ public:
 
     UTFType GetType() const { return type_; }
 
+    void Reserve(size_t size) { os_->Reserve(size); }
     void Put(Ch c) { putFunc_(*os_, c); }
     void Flush() { os_->Flush(); } 
 

--- a/include/rapidjson/filewritestream.h
+++ b/include/rapidjson/filewritestream.h
@@ -32,6 +32,8 @@ public:
         RAPIDJSON_ASSERT(fp_ != 0);
     }
 
+    void Reserve(size_t) { }
+
     void Put(char c) { 
         if (current_ >= bufferEnd_)
             Flush();

--- a/include/rapidjson/internal/stack.h
+++ b/include/rapidjson/internal/stack.h
@@ -129,7 +129,6 @@ public:
     size_t GetSize() const { return static_cast<size_t>(stackTop_ - stack_); }
     size_t GetCapacity() const { return static_cast<size_t>(stackEnd_ - stack_); }
 
-private:
     template<typename T>
     void Expand(size_t count) {
         // Only expand the capacity if the current stack exists. Otherwise just create a stack with initial capacity.
@@ -149,6 +148,7 @@ private:
         Resize(newCapacity);
     }
 
+private:
     void Resize(size_t newCapacity) {
         const size_t size = GetSize();  // Backup the current size
         stack_ = (char*)allocator_->Realloc(stack_, GetCapacity(), newCapacity);

--- a/include/rapidjson/memorybuffer.h
+++ b/include/rapidjson/memorybuffer.h
@@ -39,6 +39,7 @@ struct GenericMemoryBuffer {
 
     GenericMemoryBuffer(Allocator* allocator = 0, size_t capacity = kDefaultCapacity) : stack_(allocator, capacity) {}
 
+	void Reserve(size_t size) { stack_.Expand(size); }
     void Put(Ch c) { *stack_.template Push<Ch>() = c; }
     void Flush() {}
 

--- a/include/rapidjson/rapidjson.h
+++ b/include/rapidjson/rapidjson.h
@@ -524,6 +524,9 @@ concept Stream {
     //! \return The begin writer pointer.
     Ch* PutBegin();
 
+    //! Prepare for writing 'size' characters.
+    void Reserve(size_t size);
+
     //! Write a character.
     void Put(Ch c);
 
@@ -577,6 +580,7 @@ struct GenericStringStream {
     Ch Take() { return *src_++; }
     size_t Tell() const { return static_cast<size_t>(src_ - head_); }
 
+    void Reserve(size_t) { }
     Ch* PutBegin() { RAPIDJSON_ASSERT(false); return 0; }
     void Put(Ch) { RAPIDJSON_ASSERT(false); }
     void Flush() { RAPIDJSON_ASSERT(false); }
@@ -613,6 +617,7 @@ struct GenericInsituStringStream {
     size_t Tell() { return static_cast<size_t>(src_ - head_); }
 
     // Write
+    void Reserve(size_t) { }
     void Put(Ch c) { RAPIDJSON_ASSERT(dst_ != 0); *dst_++ = c; }
 
     Ch* PutBegin() { return dst_ = src_; }

--- a/include/rapidjson/stringbuffer.h
+++ b/include/rapidjson/stringbuffer.h
@@ -47,6 +47,7 @@ public:
     }
 #endif
 
+    void Reserve(size_t) { }
     void Put(Ch c) { *stack_.template Push<Ch>() = c; }
     void Flush() {}
 

--- a/include/rapidjson/writer.h
+++ b/include/rapidjson/writer.h
@@ -188,15 +188,15 @@ protected:
     static const size_t kDefaultLevelDepth = 32;
 
     bool WriteNull()  {
-        os_->Put('n'); os_->Put('u'); os_->Put('l'); os_->Put('l'); return true;
+        os_->Reserve(4); os_->Put('n'); os_->Put('u'); os_->Put('l'); os_->Put('l'); return true;
     }
 
     bool WriteBool(bool b)  {
         if (b) {
-            os_->Put('t'); os_->Put('r'); os_->Put('u'); os_->Put('e');
+            os_->Reserve(4); os_->Put('t'); os_->Put('r'); os_->Put('u'); os_->Put('e');
         }
         else {
-            os_->Put('f'); os_->Put('a'); os_->Put('l'); os_->Put('s'); os_->Put('e');
+            os_->Reserve(5); os_->Put('f'); os_->Put('a'); os_->Put('l'); os_->Put('s'); os_->Put('e');
         }
         return true;
     }
@@ -204,6 +204,7 @@ protected:
     bool WriteInt(int i) {
         char buffer[11];
         const char* end = internal::i32toa(i, buffer);
+        os_->Reserve(end - buffer);
         for (const char* p = buffer; p != end; ++p)
             os_->Put(*p);
         return true;
@@ -212,6 +213,7 @@ protected:
     bool WriteUint(unsigned u) {
         char buffer[10];
         const char* end = internal::u32toa(u, buffer);
+        os_->Reserve(end - buffer);
         for (const char* p = buffer; p != end; ++p)
             os_->Put(*p);
         return true;
@@ -220,6 +222,7 @@ protected:
     bool WriteInt64(int64_t i64) {
         char buffer[21];
         const char* end = internal::i64toa(i64, buffer);
+        os_->Reserve(end - buffer);
         for (const char* p = buffer; p != end; ++p)
             os_->Put(*p);
         return true;
@@ -228,6 +231,7 @@ protected:
     bool WriteUint64(uint64_t u64) {
         char buffer[20];
         char* end = internal::u64toa(u64, buffer);
+        os_->Reserve(end - buffer);
         for (char* p = buffer; p != end; ++p)
             os_->Put(*p);
         return true;
@@ -236,6 +240,7 @@ protected:
     bool WriteDouble(double d) {
         char buffer[25];
         char* end = internal::dtoa(d, buffer);
+        os_->Reserve(end - buffer);
         for (char* p = buffer; p != end; ++p)
             os_->Put(*p);
         return true;
@@ -255,6 +260,7 @@ protected:
 #undef Z16
         };
 
+        os_->Reserve(length + 2);
         os_->Put('\"');
         GenericStringStream<SourceEncoding> is(str);
         while (is.Tell() < length) {

--- a/test/perftest/rapidjsontest.cpp
+++ b/test/perftest/rapidjsontest.cpp
@@ -251,6 +251,7 @@ TEST_F(RapidJson, DocumentAccept) {
 
 struct NullStream {
     NullStream() /*: length_(0)*/ {}
+    void Reserve(size_t) { }
     void Put(char) { /*++length_;*/ }
     void Flush() {}
     //size_t length_;

--- a/test/unittest/documenttest.cpp
+++ b/test/unittest/documenttest.cpp
@@ -218,6 +218,7 @@ TEST(Document, Swap) {
 struct OutputStringStream : public std::ostringstream {
     typedef char Ch;
 
+    void Reserve(size_t) { }
     void Put(char c) {
         put(c);
     }

--- a/test/unittest/prettywritertest.cpp
+++ b/test/unittest/prettywritertest.cpp
@@ -107,6 +107,7 @@ public:
     Ch Take() { assert(false); return '\0'; }
     size_t Tell() const { return 0; }
 
+    void Reserve(size_t) { }
     Ch* PutBegin() { assert(false); return 0; }
     void Put(Ch c) { os_.put(c); }
     void Flush() { os_.flush(); }

--- a/test/unittest/writertest.cpp
+++ b/test/unittest/writertest.cpp
@@ -151,6 +151,7 @@ public:
     size_t Tell() const { return 0; }
 
     Ch* PutBegin() { assert(false); return 0; }
+    void Reserve(size_t) { }
     void Put(Ch c) { os_.put(c); }
     void Flush() { os_.flush(); }
     size_t PutEnd(Ch*) { assert(false); return 0; }


### PR DESCRIPTION
Add a 'Reserve' method to streams that is called by the writer prior to writing.

The idea here is that if you're writing to an in-memory buffer, you'll have to keep growing the buffer as new content is written to it character-by-character. When the length is known ahead of time - as it is for individual nodes - we can communicate that to the stream, and allow it to grow the buffer at most once per node.

The downside of this is that all custom streams will need an empty "Reserve" method, so it's a breaking change, though not a hard one for people to resolve.