### PR TITLE
Clarify problematic JSON license (#377)

### DIFF
--- a/license.txt
+++ b/license.txt
@@ -3,7 +3,7 @@ Tencent is pleased to support the open source community by making RapidJSON avai
 Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip.  All rights reserved.
 
 If you have downloaded a copy of the RapidJSON binary from Tencent, please note that the RapidJSON binary is licensed under the MIT License.
-If you have downloaded a copy of the RapidJSON source code from Tencent, please note that RapidJSON source code is licensed under the MIT License, except for the third-party components listed below which are subject to different license terms.  Your integration of RapidJSON into your own projects may require compliance with the MIT License, as well as the other licenses applicable to the third-party components included within RapidJSON.
+If you have downloaded a copy of the RapidJSON source code from Tencent, please note that RapidJSON source code is licensed under the MIT License, except for the third-party components listed below which are subject to different license terms.  Your integration of RapidJSON into your own projects may require compliance with the MIT License, as well as the other licenses applicable to the third-party components included within RapidJSON. To avoid the problematic JSON license in your own projects, it's sufficient to exclude the bin/jsonchecker/ directory, as it's the only code under the JSON license.
 A copy of the MIT License is included in this file.
 
 Other dependencies and licenses:


### PR DESCRIPTION
To resolve #377 the license.txt is expanded to clarify that only the JSON_checker code is under the problematic JSON license.