### PR TITLE
Implement = operator for BigInteger

### DIFF
--- a/include/rapidjson/internal/biginteger.h
+++ b/include/rapidjson/internal/biginteger.h
@@ -51,7 +51,14 @@ public:
         if (length > 0)
             AppendDecimal64(decimals + i, decimals + i + length);
     }
-
+    
+    BigInteger& operator=(const BigInteger &rhs)
+    {
+        count_ = rhs.count_;
+        std::memcpy(digits_, rhs.digits_, count_ * sizeof(Type));
+        return *this;
+    }
+    
     BigInteger& operator=(uint64_t u) {
         digits_[0] = u;            
         count_ = 1;


### PR DESCRIPTION
There's a copy constructor, but no '=' operator implemented. This is dangerous.