### PR TITLE
Add api to parse string with specified length

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -1982,7 +1982,7 @@ public:
     template <unsigned parseFlags, typename SourceEncoding>
     GenericDocument& Parse(const Ch* str, size_t len) {
         RAPIDJSON_ASSERT(!(parseFlags & kParseInsituFlag));
-        GenericStringStream<SourceEncoding> s(str, len);
+        GenericBufferStream<SourceEncoding> s(str, len);
         return ParseStream<parseFlags, SourceEncoding>(s);
     }
 

--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -1972,6 +1972,37 @@ public:
     GenericDocument& Parse(const Ch* str) {
         return Parse<kParseDefaultFlags>(str);
     }
+
+    //! Parse JSON text from a read-only string (with Encoding conversion)
+    /*! \tparam parseFlags Combination of \ref ParseFlag (must not contain \ref kParseInsituFlag).
+        \tparam SourceEncoding Transcoding from input Encoding
+        \param str Read-only string to be parsed.
+        \param len The length of the string.
+    */
+    template <unsigned parseFlags, typename SourceEncoding>
+    GenericDocument& Parse(const Ch* str, size_t len) {
+        RAPIDJSON_ASSERT(!(parseFlags & kParseInsituFlag));
+        GenericStringStream<SourceEncoding> s(str, len);
+        return ParseStream<parseFlags, SourceEncoding>(s);
+    }
+
+    //! Parse JSON text from a read-only string with length
+    /*! \tparam parseFlags Combination of \ref ParseFlag (must not contain \ref kParseInsituFlag).
+        \param str Read-only string to be parsed.
+        \param len The length of the string.
+    */
+    template <unsigned parseFlags>
+    GenericDocument& Parse(const Ch* str, size_t len) {
+        return Parse<parseFlags, Encoding>(str, len);
+    }
+
+    //! Parse JSON text from a read-only string with length (with \ref kParseDefaultFlags)
+    /*! \param str Read-only string to be parsed.
+        \param len The length of the string.
+    */
+    GenericDocument& Parse(const Ch* str, size_t len) {
+        return Parse<kParseDefaultFlags>(str, len);
+    }
     //!@}
 
     //!@name Handling parse errors

--- a/include/rapidjson/rapidjson.h
+++ b/include/rapidjson/rapidjson.h
@@ -566,12 +566,12 @@ inline void PutN(Stream& stream, Ch c, size_t n) {
 
 //! Read-only string stream.
 /*! \note implements Stream concept
- */
+*/
 template <typename Encoding>
 struct GenericStringStream {
     typedef typename Encoding::Ch Ch;
 
-GenericStringStream(const Ch *src) : src_(src), head_(src) {}
+    GenericStringStream(const Ch *src) : src_(src), head_(src) {}
 
     Ch Peek() const { return *src_; }
     Ch Take() { return *src_++; }

--- a/include/rapidjson/rapidjson.h
+++ b/include/rapidjson/rapidjson.h
@@ -566,22 +566,15 @@ inline void PutN(Stream& stream, Ch c, size_t n) {
 
 //! Read-only string stream.
 /*! \note implements Stream concept
-*/
+ */
 template <typename Encoding>
 struct GenericStringStream {
     typedef typename Encoding::Ch Ch;
 
-    GenericStringStream(const Ch *src) : 
-        src_(src), head_(src), length_(0), idx_(0) {}
-    GenericStringStream(const Ch *src, size_t len) : 
-        src_(src), head_(src), length_(len), idx_(0) {}
+GenericStringStream(const Ch *src) : src_(src), head_(src) {}
 
     Ch Peek() const { return *src_; }
-    Ch Take() { 
-        if (length_ == 0) return *src_++;
-        else if (idx_++ != length_) return *src_++;
-        else { ++src_; return '\0'; } // Tell() should be ok.
-    }
+    Ch Take() { return *src_++; }
     size_t Tell() const { return static_cast<size_t>(src_ - head_); }
 
     Ch* PutBegin() { RAPIDJSON_ASSERT(false); return 0; }
@@ -591,8 +584,6 @@ struct GenericStringStream {
 
     const Ch* src_;     //!< Current read position.
     const Ch* head_;    //!< Original head of the string.
-    size_t length_;
-    size_t idx_;
 };
 
 template <typename Encoding>
@@ -602,6 +593,45 @@ struct StreamTraits<GenericStringStream<Encoding> > {
 
 //! String stream with UTF8 encoding.
 typedef GenericStringStream<UTF8<> > StringStream;
+
+///////////////////////////////////////////////////////////////////////////////
+// BufferStream
+
+//! Read-only buffer stream.
+/*! \note implements Stream concept
+*/
+template <typename Encoding>
+struct GenericBufferStream {
+    typedef typename Encoding::Ch Ch;
+
+    GenericBufferStream(const Ch *src, size_t len) : 
+        src_(src), length_(len), idx_(0) {}
+
+    Ch Peek() const { return src_[idx_]; }
+    Ch Take() {
+        if (idx_ != length_) return src_[idx_++];
+        else return '\0';
+    }
+    size_t Tell() const { return idx_; }
+
+    Ch* PutBegin() { RAPIDJSON_ASSERT(false); return 0; }
+    void Put(Ch) { RAPIDJSON_ASSERT(false); }
+    void Flush() { RAPIDJSON_ASSERT(false); }
+    size_t PutEnd(Ch*) { RAPIDJSON_ASSERT(false); return 0; }
+
+    const Ch* src_;     //!< Original buffer pointer.
+    size_t length_;     //!< The length of buffer.
+    size_t idx_;        //!< Current read position.
+};
+
+template <typename Encoding>
+struct StreamTraits<GenericBufferStream<Encoding> > {
+    enum { copyOptimization = 1 };
+};
+
+//! Buffer stream with UTF8 encoding.
+typedef GenericBufferStream<UTF8<> > BufferStream;
+
 
 ///////////////////////////////////////////////////////////////////////////////
 // InsituStringStream

--- a/include/rapidjson/rapidjson.h
+++ b/include/rapidjson/rapidjson.h
@@ -571,10 +571,17 @@ template <typename Encoding>
 struct GenericStringStream {
     typedef typename Encoding::Ch Ch;
 
-    GenericStringStream(const Ch *src) : src_(src), head_(src) {}
+    GenericStringStream(const Ch *src) : 
+        src_(src), head_(src), length_(0), idx_(0) {}
+    GenericStringStream(const Ch *src, size_t len) : 
+        src_(src), head_(src), length_(len), idx_(0) {}
 
     Ch Peek() const { return *src_; }
-    Ch Take() { return *src_++; }
+    Ch Take() { 
+        if (length_ == 0) return *src_++;
+        else if (idx_++ != length_) return *src_++;
+        else { ++src_; return '\0'; } // Tell() should be ok.
+    }
     size_t Tell() const { return static_cast<size_t>(src_ - head_); }
 
     Ch* PutBegin() { RAPIDJSON_ASSERT(false); return 0; }
@@ -584,6 +591,8 @@ struct GenericStringStream {
 
     const Ch* src_;     //!< Current read position.
     const Ch* head_;    //!< Original head of the string.
+    size_t length_;
+    size_t idx_;
 };
 
 template <typename Encoding>


### PR DESCRIPTION
Added new BufferStream to parse string.
[issue 415](https://github.com/miloyip/rapidjson/issues/415)