### PR TITLE
Issue 430, implemented std::iostream support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+  * new classes IOStreamReadStream and IOStreamWriterStream that supports std::iostream
 
 ## [1.0.2] - 2015-05-14
 
@@ -17,7 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 * CMakeLists for include as a thirdparty in projects (#334, #337)
-* Change Document::ParseStream() to use stack allocator for Reader (ffbe38614732af8e0b3abdc8b50071f386a4a685) 
+* Change Document::ParseStream() to use stack allocator for Reader (ffbe38614732af8e0b3abdc8b50071f386a4a685)
 
 ## [1.0.1] - 2015-04-25
 

--- a/include/rapidjson/iostreamreadstream.h
+++ b/include/rapidjson/iostreamreadstream.h
@@ -71,8 +71,8 @@ public:
   //! For encoding detection only, called at the start on openning a stream.
   const Ch* Peek4() const {
     istream_.get(peekBuffer_, 4);
-    int n = istream_.gcount() - 1;
-    for(int i = 0; i <= n; ++i) {
+    std::streamsize n = istream_.gcount() - 1;
+    for(std::streamsize i = 0; i <= n; ++i) {
       istream_.putback(peekBuffer_[n - i]);
     }
     return peekBuffer_;

--- a/include/rapidjson/iostreamreadstream.h
+++ b/include/rapidjson/iostreamreadstream.h
@@ -41,14 +41,17 @@ public:
   {
     // given the Reader Concept, we need to explicitly check for eof and return '\0'
     int v = istream_.peek();
-    if(v == std::char_traits<wchar_t>::eof()) return '\0';
+    if(v == std::char_traits<Ch>::eof()) return '\0';
     return v;
   }
 
   //! Extract the next character in the stream.
   Ch Take()
   {
-    return (istream_.eof()) ? '\0' : istream_.get();
+    // given the Reader Concept, we need to explicitly check for eof and return '\0'
+    int v = istream_.get();
+    if(v == std::char_traits<Ch>::eof()) return '\0';
+    return v;
   }
 
   //! Where are we in the stream.

--- a/include/rapidjson/iostreamreadstream.h
+++ b/include/rapidjson/iostreamreadstream.h
@@ -1,4 +1,6 @@
-// Copyright (C) 2015 Bruno Nicoletti. All rights reserved.
+// Tencent is pleased to support the open source community by making RapidJSON available.
+//
+// Copyright (C) 2015 THL A29 Limited, a Tencent company, Milo Yip and Bruno Nicoletti. All rights reserved.
 //
 // Licensed under the MIT License (the "License"); you may not use this file except
 // in compliance with the License. You may obtain a copy of the License at

--- a/include/rapidjson/iostreamreadstream.h
+++ b/include/rapidjson/iostreamreadstream.h
@@ -22,67 +22,65 @@ RAPIDJSON_NAMESPACE_BEGIN
 
 //! File byte stream for input using fread().
 /*!
-    \note implements Stream concept
+        \note implements Stream concept
 */
 class IOStreamReadStream {
 public:
-  typedef char Ch;    //!< Character type (byte).
+    typedef char Ch;    //!< Character type (byte).
 
-  //! Constructor.
-  /*!
-    \param An open istream to read from.
-  */
-  IOStreamReadStream(std::istream &stream)
-    : istream_(stream)
-  {
-    peekBuffer_[0] = peekBuffer_[1] = peekBuffer_[2] = peekBuffer_[3] = 0;
-  }
-
-  //! Look at the next character in the stream without consuming it. Returns '\0' on eof.
-  Ch Peek() const
-  {
-    // given the Reader Concept, we need to explicitly check for eof and return '\0'
-    int v = istream_.peek();
-    if(v == std::char_traits<Ch>::eof()) return '\0';
-    return v;
-  }
-
-  //! Extract the next character in the stream.
-  Ch Take()
-  {
-    // given the Reader Concept, we need to explicitly check for eof and return '\0'
-    int v = istream_.get();
-    if(v == std::char_traits<Ch>::eof()) return '\0';
-    return v;
-  }
-
-  //! Where are we in the stream.
-  size_t Tell() const
-  {
-    return istream_.tellg();
-  }
-
-  // Not implemented
-  void Put(Ch) { RAPIDJSON_ASSERT(false); }
-  void Flush() { RAPIDJSON_ASSERT(false); }
-  Ch* PutBegin() { RAPIDJSON_ASSERT(false); return 0; }
-  size_t PutEnd(Ch*) { RAPIDJSON_ASSERT(false); return 0; }
-
-  //! Get a pointer to the next four characters in the stream.
-  //!
-  //! For encoding detection only, called at the start on openning a stream.
-  const Ch* Peek4() const {
-    istream_.get(peekBuffer_, 4);
-    std::streamsize n = istream_.gcount() - 1;
-    for(std::streamsize i = 0; i <= n; ++i) {
-      istream_.putback(peekBuffer_[n - i]);
+    //! Constructor.
+    /*!
+        \param An open istream to read from.
+    */
+    IOStreamReadStream(std::istream &stream)
+        : istream_(stream) {
+        peekBuffer_[0] = peekBuffer_[1] = peekBuffer_[2] = peekBuffer_[3] = 0;
     }
-    return peekBuffer_;
-  }
+
+    //! Look at the next character in the stream without consuming it. Returns '\0' on eof.
+    Ch Peek() const {
+        int v = istream_.peek();
+        if(!istream_ || v == std::char_traits<char>::eof()) return Ch('\0');
+        return Ch(v);
+    }
+
+    //! Extract the next character in the stream.
+    Ch Take() {
+        char ch;
+        if(istream_.get(ch)) {
+            return Ch(ch);
+        }
+        else {
+            return Ch('\0');
+        }
+    }
+
+    //! Where are we in the stream.
+    size_t Tell() const {
+        return istream_.tellg();
+    }
+
+    // Not implemented
+    void Put(Ch) { RAPIDJSON_ASSERT(false); }
+    void Flush() { RAPIDJSON_ASSERT(false); }
+    Ch* PutBegin() { RAPIDJSON_ASSERT(false); return 0; }
+    size_t PutEnd(Ch*) { RAPIDJSON_ASSERT(false); return 0; }
+
+    //! Get a pointer to the next four characters in the stream.
+    //!
+    //! For encoding detection only, called at the start on openning a stream.
+    const Ch* Peek4() const {
+        istream_.get(peekBuffer_, 4);
+        std::streamsize n = istream_.gcount() - 1;
+        for(std::streamsize i = 0; i <= n; ++i) {
+            istream_.putback(peekBuffer_[n - i]);
+        }
+        return peekBuffer_;
+    }
 
 private:
-  std::istream& istream_;
-  mutable Ch peekBuffer_[4]; ///< need for the Peek4 nastyness
+    std::istream& istream_;
+    mutable Ch peekBuffer_[4]; ///< need for the Peek4 nastyness
 };
 
 RAPIDJSON_NAMESPACE_END

--- a/include/rapidjson/iostreamreadstream.h
+++ b/include/rapidjson/iostreamreadstream.h
@@ -1,0 +1,85 @@
+// Copyright (C) 2015 Bruno Nicoletti. All rights reserved.
+//
+// Licensed under the MIT License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://opensource.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#ifndef RAPIDJSON_IOSTREAMREADSTREAM_H_
+#define RAPIDJSON_IOSTREAMREADSTREAM_H_
+
+#include <istream>
+#include "rapidjson.h"
+
+RAPIDJSON_NAMESPACE_BEGIN
+
+//! File byte stream for input using fread().
+/*!
+    \note implements Stream concept
+*/
+class IOStreamReadStream {
+public:
+  typedef char Ch;    //!< Character type (byte).
+
+  //! Constructor.
+  /*!
+    \param An open istream to read from.
+  */
+  IOStreamReadStream(std::istream &stream)
+    : istream_(stream)
+  {
+    peekBuffer_[0] = peekBuffer_[1] = peekBuffer_[2] = peekBuffer_[3] = 0;
+  }
+
+  //! Look at the next character in the stream without consuming it. Returns '\0' on eof.
+  Ch Peek() const
+  {
+    // given the Reader Concept, we need to explicitly check for eof and return '\0'
+    int v = istream_.peek();
+    if(v == std::char_traits<wchar_t>::eof()) return '\0';
+    return v;
+  }
+
+  //! Extract the next character in the stream.
+  Ch Take()
+  {
+    return (istream_.eof()) ? '\0' : istream_.get();
+  }
+
+  //! Where are we in the stream.
+  size_t Tell() const
+  {
+    return istream_.tellg();
+  }
+
+  // Not implemented
+  void Put(Ch) { RAPIDJSON_ASSERT(false); }
+  void Flush() { RAPIDJSON_ASSERT(false); }
+  Ch* PutBegin() { RAPIDJSON_ASSERT(false); return 0; }
+  size_t PutEnd(Ch*) { RAPIDJSON_ASSERT(false); return 0; }
+
+  //! Get a pointer to the next four characters in the stream.
+  //!
+  //! For encoding detection only, called at the start on openning a stream.
+  const Ch* Peek4() const {
+    istream_.get(peekBuffer_, 4);
+    int n = istream_.gcount() - 1;
+    for(int i = 0; i <= n; ++i) {
+      istream_.putback(peekBuffer_[n - i]);
+    }
+    return peekBuffer_;
+  }
+
+private:
+  std::istream& istream_;
+  mutable Ch peekBuffer_[4]; ///< need for the Peek4 nastyness
+};
+
+RAPIDJSON_NAMESPACE_END
+
+#endif // RAPIDJSON_STDSTREAMSTREAM_H_

--- a/include/rapidjson/iostreamwritestream.h
+++ b/include/rapidjson/iostreamwritestream.h
@@ -1,0 +1,62 @@
+// Copyright (C) 2015 Bruno Nicoletti. All rights reserved.
+//
+// Licensed under the MIT License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://opensource.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+#ifndef RAPIDJSON_IOSTREAMWRITESTREAM_H_
+#define RAPIDJSON_IOSTREAMWRITESTREAM_H_
+
+#include <iostream>
+
+#include "rapidjson.h"
+
+RAPIDJSON_NAMESPACE_BEGIN
+
+//! File byte stream for output using a std::ostream.
+/*!
+  \note implements Stream concept
+*/
+
+class IOStreamWriteStream {
+public:
+  typedef char Ch;    //!< Character type. Only support char.
+
+  //! Constructor, takes a reference to an std::ostream
+  IOStreamWriteStream(std::ostream &stream)
+    : ostream_(stream)
+  {
+  }
+
+  //! Put a character out to the ostream.
+  void Put(char c) {
+    ostream_.put(c);
+  }
+
+  //! Flush the ostream.
+  void Flush() {
+    ostream_.flush();
+  }
+
+  // Not implemented
+  char Peek() const { RAPIDJSON_ASSERT(false); return 0; }
+  char Take() { RAPIDJSON_ASSERT(false); return 0; }
+  size_t Tell() const { RAPIDJSON_ASSERT(false); return 0; }
+  char* PutBegin() { RAPIDJSON_ASSERT(false); return 0; }
+  size_t PutEnd(char*) { RAPIDJSON_ASSERT(false); return 0; }
+
+private:
+  // Prohibit copy constructor & assignment operator.
+  IOStreamWriteStream(const IOStreamWriteStream&);
+  IOStreamWriteStream& operator=(const IOStreamWriteStream&);
+
+  std::ostream &ostream_;
+};
+
+RAPIDJSON_NAMESPACE_END
+#endif // RAPIDJSON_IOSTREAMWRITESTREAM_H_

--- a/include/rapidjson/iostreamwritestream.h
+++ b/include/rapidjson/iostreamwritestream.h
@@ -1,4 +1,6 @@
-// Copyright (C) 2015 Bruno Nicoletti. All rights reserved.
+// Tencent is pleased to support the open source community by making RapidJSON available.
+//
+// Copyright (C) 2015 THL A29 Limited, a Tencent company, Milo Yip and Bruno Nicoletti. All rights reserved.
 //
 // Licensed under the MIT License (the "License"); you may not use this file except
 // in compliance with the License. You may obtain a copy of the License at

--- a/include/rapidjson/iostreamwritestream.h
+++ b/include/rapidjson/iostreamwritestream.h
@@ -22,42 +22,41 @@ RAPIDJSON_NAMESPACE_BEGIN
 
 //! File byte stream for output using a std::ostream.
 /*!
-  \note implements Stream concept
+    \note implements Stream concept
 */
 
 class IOStreamWriteStream {
 public:
-  typedef char Ch;    //!< Character type. Only support char.
+    typedef char Ch;    //!< Character type. Only support char.
 
-  //! Constructor, takes a reference to an std::ostream
-  IOStreamWriteStream(std::ostream &stream)
-    : ostream_(stream)
-  {
-  }
+    //! Constructor, takes a reference to an std::ostream
+    IOStreamWriteStream(std::ostream &stream)
+        : ostream_(stream) {
+    }
 
-  //! Put a character out to the ostream.
-  void Put(char c) {
-    ostream_.put(c);
-  }
+    //! Put a character out to the ostream.
+    void Put(char c) {
+        ostream_.put(c);
+    }
 
-  //! Flush the ostream.
-  void Flush() {
-    ostream_.flush();
-  }
+    //! Flush the ostream.
+    void Flush() {
+        ostream_.flush();
+    }
 
-  // Not implemented
-  char Peek() const { RAPIDJSON_ASSERT(false); return 0; }
-  char Take() { RAPIDJSON_ASSERT(false); return 0; }
-  size_t Tell() const { RAPIDJSON_ASSERT(false); return 0; }
-  char* PutBegin() { RAPIDJSON_ASSERT(false); return 0; }
-  size_t PutEnd(char*) { RAPIDJSON_ASSERT(false); return 0; }
+    // Not implemented
+    char Peek() const { RAPIDJSON_ASSERT(false); return 0; }
+    char Take() { RAPIDJSON_ASSERT(false); return 0; }
+    size_t Tell() const { RAPIDJSON_ASSERT(false); return 0; }
+    char* PutBegin() { RAPIDJSON_ASSERT(false); return 0; }
+    size_t PutEnd(char*) { RAPIDJSON_ASSERT(false); return 0; }
 
 private:
-  // Prohibit copy constructor & assignment operator.
-  IOStreamWriteStream(const IOStreamWriteStream&);
-  IOStreamWriteStream& operator=(const IOStreamWriteStream&);
+    // Prohibit copy constructor & assignment operator.
+    IOStreamWriteStream(const IOStreamWriteStream&);
+    IOStreamWriteStream& operator=(const IOStreamWriteStream&);
 
-  std::ostream &ostream_;
+    std::ostream &ostream_;
 };
 
 RAPIDJSON_NAMESPACE_END

--- a/readme.md
+++ b/readme.md
@@ -2,11 +2,13 @@
 
 ![](https://img.shields.io/badge/release-v1.0.2-blue.png)
 
-## A fast JSON parser/generator for C++ with both SAX/DOM style API 
+## A fast JSON parser/generator for C++ with both SAX/DOM style API
 
 Tencent is pleased to support the open source community by making RapidJSON available.
 
 Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip. All rights reserved.
+
+Some contributions are additionally Copyright (C) 2015 Bruno Nicoletti. All rights reserved. See individual files for details.
 
 * [RapidJSON GitHub](https://github.com/miloyip/rapidjson/)
 * RapidJSON Documentation

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -1,17 +1,18 @@
 set(UNITTEST_SOURCES
-	allocatorstest.cpp
+  allocatorstest.cpp
     bigintegertest.cpp
     documenttest.cpp
     encodedstreamtest.cpp
     encodingstest.cpp
     filestreamtest.cpp
+    iostreamtest.cpp
     itoatest.cpp
     jsoncheckertest.cpp
     namespacetest.cpp
     pointertest.cpp
     prettywritertest.cpp
     readertest.cpp
-	simdtest.cpp
+  simdtest.cpp
     stringbuffertest.cpp
     strtodtest.cpp
     unittest.cpp

--- a/test/unittest/iostreamtest.cpp
+++ b/test/unittest/iostreamtest.cpp
@@ -1,0 +1,125 @@
+// Tencent is pleased to support the open source community by making RapidJSON available.
+//
+// Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip. All rights reserved.
+//
+// Licensed under the MIT License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://opensource.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include <fstream>
+#include <stdio.h>
+
+#include "unittest.h"
+#include "rapidjson/iostreamreadstream.h"
+#include "rapidjson/iostreamwritestream.h"
+#include "rapidjson/encodedstream.h"
+
+using namespace rapidjson;
+
+class IOStreamStreamTest : public ::testing::Test {
+public:
+    IOStreamStreamTest() : filename_(), json_(), length_() {}
+
+    virtual void SetUp() {
+        const char *paths[] = {
+            "data/sample.json",
+            "bin/data/sample.json",
+            "../bin/data/sample.json",
+            "../../bin/data/sample.json",
+            "../../../bin/data/sample.json"
+        };
+        FILE* fp = 0;
+        for (size_t i = 0; i < sizeof(paths) / sizeof(paths[0]); i++) {
+            fp = fopen(paths[i], "rb");
+            if (fp) {
+                filename_ = paths[i];
+                break;
+            }
+        }
+        ASSERT_TRUE(fp != 0);
+
+        fseek(fp, 0, SEEK_END);
+        length_ = (size_t)ftell(fp);
+        fseek(fp, 0, SEEK_SET);
+        json_ = (char*)malloc(length_ + 1);
+        size_t readLength = fread(json_, 1, length_, fp);
+        json_[readLength] = '\0';
+        fclose(fp);
+    }
+
+    virtual void TearDown() {
+        free(json_);
+        json_ = 0;
+    }
+
+private:
+    IOStreamStreamTest(const IOStreamStreamTest&);
+    IOStreamStreamTest& operator=(const IOStreamStreamTest&);
+
+protected:
+    const char* filename_;
+    char *json_;
+    size_t length_;
+};
+
+TEST_F(IOStreamStreamTest, IOStreamReadStream) {
+
+  //#if _MSC_VER
+    std::ifstream stream(filename_, std::ios_base::in | std::ios_base::binary);
+    //#else
+    //std::ifstream stream(filename_);
+    //#endif
+
+    ASSERT_TRUE(stream.good());
+    IOStreamReadStream s(stream);
+
+    for (size_t i = 0; i < length_; i++) {
+        EXPECT_EQ(json_[i], s.Peek());
+        EXPECT_EQ(json_[i], s.Peek());  // 2nd time should be the same
+        EXPECT_EQ(json_[i], s.Take());
+    }
+
+    EXPECT_EQ(length_, s.Tell());
+    EXPECT_EQ('\0', s.Peek());
+}
+
+TEST_F(IOStreamStreamTest, IOStreamWriteStream) {
+    char filename[L_tmpnam];
+    TempFileName(filename);
+    {
+      // scope the stream so it shut at the end of the block
+#if _MSC_VER
+      std::ofstream stream(filename, std::ios_base::out | std::ios_base::binary);
+#else
+      std::ofstream stream(filename, std::ios_base::out);
+#endif
+      ASSERT_TRUE(stream.good());
+
+      IOStreamWriteStream os(stream);
+      for (size_t i = 0; i < length_; i++)
+        os.Put(json_[i]);
+      os.Flush();
+    }
+
+    // Read it back to verify
+#if _MSC_VER
+    std::ifstream istream(filename_, std::ios_base::in | std::ios_base::binary);
+#else
+    std::ifstream istream(filename_);
+#endif
+    IOStreamReadStream is(istream);
+
+    for (size_t i = 0; i < length_; i++)
+        EXPECT_EQ(json_[i], is.Take());
+
+    EXPECT_EQ(length_, is.Tell());
+
+    //std::cout << filename << std::endl;
+    remove(filename);
+}

--- a/test/unittest/iostreamtest.cpp
+++ b/test/unittest/iostreamtest.cpp
@@ -70,18 +70,18 @@ protected:
 
 TEST_F(IOStreamStreamTest, IOStreamReadStream) {
 
-  //#if _MSC_VER
+//#if _MSC_VER
     std::ifstream stream(filename_, std::ios_base::in | std::ios_base::binary);
-    //#else
+//#else
     //std::ifstream stream(filename_);
-    //#endif
+//#endif
 
     ASSERT_TRUE(stream.good());
     IOStreamReadStream s(stream);
 
     for (size_t i = 0; i < length_; i++) {
         EXPECT_EQ(json_[i], s.Peek());
-        EXPECT_EQ(json_[i], s.Peek());  // 2nd time should be the same
+        EXPECT_EQ(json_[i], s.Peek());    // 2nd time should be the same
         EXPECT_EQ(json_[i], s.Take());
     }
 
@@ -93,18 +93,18 @@ TEST_F(IOStreamStreamTest, IOStreamWriteStream) {
     char filename[L_tmpnam];
     TempFileName(filename);
     {
-      // scope the stream so it shut at the end of the block
+        // scope the std::ofstream so it shuts at the end of the block
 #if _MSC_VER
-      std::ofstream stream(filename, std::ios_base::out | std::ios_base::binary);
+        std::ofstream stream(filename, std::ios_base::out | std::ios_base::binary);
 #else
-      std::ofstream stream(filename, std::ios_base::out);
+        std::ofstream stream(filename, std::ios_base::out);
 #endif
-      ASSERT_TRUE(stream.good());
+        ASSERT_TRUE(stream.good());
 
-      IOStreamWriteStream os(stream);
-      for (size_t i = 0; i < length_; i++)
-        os.Put(json_[i]);
-      os.Flush();
+        IOStreamWriteStream os(stream);
+        for (size_t i = 0; i < length_; i++)
+            os.Put(json_[i]);
+        os.Flush();
     }
 
     // Read it back to verify

--- a/test/unittest/iostreamtest.cpp
+++ b/test/unittest/iostreamtest.cpp
@@ -1,6 +1,6 @@
 // Tencent is pleased to support the open source community by making RapidJSON available.
 //
-// Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip. All rights reserved.
+// Copyright (C) 2015 THL A29 Limited, a Tencent company, Milo Yip and Bruno Nicoletti. All rights reserved.
 //
 // Licensed under the MIT License (the "License"); you may not use this file except
 // in compliance with the License. You may obtain a copy of the License at

--- a/test/unittest/unittest.h
+++ b/test/unittest/unittest.h
@@ -1,6 +1,6 @@
 // Tencent is pleased to support the open source community by making RapidJSON available.
 //
-// Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip. All rights reserved.
+// Copyright (C) 2015 THL A29 Limited, a Tencent company, Milo Yip and Bruno Nicoletti. All rights reserved.
 //
 // Licensed under the MIT License (the "License"); you may not use this file except
 // in compliance with the License. You may obtain a copy of the License at

--- a/test/unittest/unittest.h
+++ b/test/unittest/unittest.h
@@ -1,5 +1,5 @@
 // Tencent is pleased to support the open source community by making RapidJSON available.
-// 
+//
 // Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip. All rights reserved.
 //
 // Licensed under the MIT License (the "License"); you may not use this file except
@@ -7,9 +7,9 @@
 //
 // http://opensource.org/licenses/MIT
 //
-// Unless required by applicable law or agreed to in writing, software distributed 
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
 #ifndef UNITTEST_H_
@@ -62,6 +62,22 @@ inline Ch* StrDup(const Ch* str) {
     return buffer;
 }
 
+inline char* TempFileName(char *filename) {
+#if _MSC_VER
+    filename = tmpnam(filename);
+    // For Visual Studio, tmpnam() adds a backslash in front. Remove it.
+    if (filename[0] == '\\')
+        for (int i = 0; filename[i] != '\0'; i++)
+            filename[i] = filename[i + 1];
+#else
+    // turn off this warning because there are no alternatives
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    filename = tmpnam(filename);
+#pragma GCC diagnostic error "-Wdeprecated-declarations"
+#endif
+    return filename;
+}
+
 inline FILE* TempFile(char *filename) {
 #if _MSC_VER
     filename = tmpnam(filename);
@@ -70,7 +86,7 @@ inline FILE* TempFile(char *filename) {
     if (filename[0] == '\\')
         for (int i = 0; filename[i] != '\0'; i++)
             filename[i] = filename[i + 1];
-        
+
     return fopen(filename, "wb");
 #else
     strcpy(filename, "/tmp/fileXXXXXX");


### PR DESCRIPTION
I've gone and implemented std::iostream support in the issue-430 branch. This is done in two independent header files. A unit test cpp file has also been added to test them, based on the existing unit test for FILE *.

I've added two new header files and a new unit test. I have modified the unittest.h header file to add a function that names a . It all passes unit tests on my mac quite happily. 

Please have a look and if you are happy pull them onto your master branch.