### PR TITLE
Writer refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+* Refactored Writer and PrettyWriter to both directly inherit from new class WriterBase and moved all common code into WriterBase. Much less code.
+* WriterBase extends Writer and PrettyWriter by adding overloaded functor methods that write values, ie: bool operator()(TYPE value) where TYPE is one of the types you can write to JSON.
+* WriterBase extends Writer and PrettyWriter by adding overloaded functor methods that write key/value pair. ie bool operator()(char *key, TYPE value) where TYPE is one of the types you can write to JSON.
+* WriterBase has overloaded all functions that take a string as a parameter in such a way that it can differentiate between string literals and char * variables. It avoids a redundant strlen call for string literals as the length is known at compile time.
+* Added new classes ObjectBlock and ArrayBlock. On construction they will start and Object/Array and on destruction close and Object/Array automatically. Reduces bugs and complexity of code by removing the need to remember to close and open Object/Array.
 
 ## [1.0.2] - 2015-05-14
 
@@ -17,7 +22,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 * CMakeLists for include as a thirdparty in projects (#334, #337)
-* Change Document::ParseStream() to use stack allocator for Reader (ffbe38614732af8e0b3abdc8b50071f386a4a685) 
+* Change Document::ParseStream() to use stack allocator for Reader (ffbe38614732af8e0b3abdc8b50071f386a4a685)
 
 ## [1.0.1] - 2015-04-25
 

--- a/include/rapidjson/autoblocks.h
+++ b/include/rapidjson/autoblocks.h
@@ -66,6 +66,10 @@ public :
   }
 protected :
   WRITER *writer_;
+
+private :
+  ObjectBlock(const ObjectBlock&);
+  ObjectBlock& operator=(const ObjectBlock&);
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -120,6 +124,11 @@ public :
 
 protected :
   WRITER *writer_;
+
+private :
+  // disable copy constructor and assignment
+  ArrayBlock(const ArrayBlock&);
+  ArrayBlock& operator=(const ArrayBlock&);
 };
 
 RAPIDJSON_NAMESPACE_END

--- a/include/rapidjson/autoblocks.h
+++ b/include/rapidjson/autoblocks.h
@@ -1,0 +1,101 @@
+// Copyright (C) 2015 Bruno Nicoletti
+//
+// Licensed under the MIT License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://opensource.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#ifndef RAPIDJSON_AUTOBLOCKS_H_
+#define RAPIDJSON_AUTOBLOCKS_H_
+
+RAPIDJSON_NAMESPACE_BEGIN
+
+////////////////////////////////////////////////////////////////////////////////
+/// Class to start and automatically close a JSON object on the given writer
+/// when it goes out of scope.
+///
+/// \tparam WRITER - a class derived from WriterBase.
+template<class WRITER>
+class ObjectBlock {
+public :
+  /// \brief Constructor,
+  ///
+  /// \param the writer to open the object on and eventually close.
+  ObjectBlock(WRITER &writer)
+    : writer_(&w)
+  {
+    writer_->StartObject();
+  }
+
+#if __cplusplus >= 201103
+  /// \brief Move copy constructor, used by helper function in BaseWriter
+  ///
+  /// This steals the writer from the src ObjectBlock. Allows for
+  /// function returns and assignements.
+  ObjectBlock(ObjectBlockBlock &&src)
+    : writer_(src.writer_)
+  {
+    src.writer_ = NULL;
+  }
+#endif
+
+  /// \brief Destructor, calls EndObject on writer
+  ~ObjectBlock()
+  {
+    if(writer_) {
+      writer_->EndObject();
+    }
+  }
+protected :
+  WRITER *writer_;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+/// Class to start and automatically close a JSON array on the given writer
+/// when it goes out of scope.
+///
+/// \tparam WRITER - a class derived from WriterBase.
+template<class WRITER>
+class ArrayBlock {
+public :
+  /// \brief Constructor,
+  ///
+  /// \param the writer to open the object on and eventually close.
+  ArrayBlock(WRITER &w)
+    : writer_(&w)
+  {
+    writer_->StartArray();
+  }
+
+#if __cplusplus >= 201103
+  /// \brief Move copy constructor, used by helper function in BaseWriter
+  ///
+  /// This steals the writer from the src ArrayBlock. Allows for
+  /// function returns and assignements.
+  ArrayBlock(ArrayBlock &&src)
+    : writer_(src.writer_)
+  {
+    src.writer_ = NULL;
+  }
+#endif
+
+  /// \brief Destructor, calls EndArray on writer
+  ~ArrayBlock()
+  {
+    if(writer_) {
+      writer_->EndArray();
+    }
+  }
+
+protected :
+  WRITER *writer_;
+};
+
+RAPIDJSON_NAMESPACE_END
+
+#endif // RAPIDJSON_RAPIDJSON_H_

--- a/include/rapidjson/autoblocks.h
+++ b/include/rapidjson/autoblocks.h
@@ -1,4 +1,6 @@
-// Copyright (C) 2015 Bruno Nicoletti
+// Tencent is pleased to support the open source community by making RapidJSON available.
+//
+// Copyright (C) 2015 THL A29 Limited, a Tencent company, Milo Yip and Bruno Nicoletti. All rights reserved.
 //
 // Licensed under the MIT License (the "License"); you may not use this file except
 // in compliance with the License. You may obtain a copy of the License at

--- a/include/rapidjson/autoblocks.h
+++ b/include/rapidjson/autoblocks.h
@@ -32,6 +32,19 @@ public :
     writer_->StartObject();
   }
 
+  /// \brief Constructor,
+  ///
+  /// \param writer the writer to open the object on and eventually close.
+  /// \param key the key to give this object
+  template <class T>
+  ObjectBlock(WRITER &writer,
+              const T &key)
+    : writer_(&w)
+  {
+    writer.Key(key);
+    writer_->StartObject();
+  }
+
 #if __cplusplus >= 201103
   /// \brief Move copy constructor, used by helper function in BaseWriter
   ///
@@ -69,6 +82,19 @@ public :
   ArrayBlock(WRITER &w)
     : writer_(&w)
   {
+    writer_->StartArray();
+  }
+
+  /// \brief Constructor,
+  ///
+  /// \param writer the writer to open the array on and eventually close.
+  /// \param key the key to give this object
+  template <class T>
+  ArrayBlock(WRITER &writer,
+             const T &key)
+    : writer_(&w)
+  {
+    writer.Key(key);
     writer_->StartArray();
   }
 

--- a/include/rapidjson/autoblocks.h
+++ b/include/rapidjson/autoblocks.h
@@ -27,7 +27,7 @@ public :
   ///
   /// \param the writer to open the object on and eventually close.
   ObjectBlock(WRITER &writer)
-    : writer_(&w)
+    : writer_(&writer)
   {
     writer_->StartObject();
   }
@@ -39,7 +39,7 @@ public :
   template <class T>
   ObjectBlock(WRITER &writer,
               const T &key)
-    : writer_(&w)
+    : writer_(&writer)
   {
     writer.Key(key);
     writer_->StartObject();
@@ -79,8 +79,8 @@ public :
   /// \brief Constructor,
   ///
   /// \param the writer to open the object on and eventually close.
-  ArrayBlock(WRITER &w)
-    : writer_(&w)
+  ArrayBlock(WRITER &writer)
+    : writer_(&writer)
   {
     writer_->StartArray();
   }
@@ -92,7 +92,7 @@ public :
   template <class T>
   ArrayBlock(WRITER &writer,
              const T &key)
-    : writer_(&w)
+    : writer_(&writer)
   {
     writer.Key(key);
     writer_->StartArray();

--- a/include/rapidjson/prettywriter.h
+++ b/include/rapidjson/prettywriter.h
@@ -1,5 +1,5 @@
 // Tencent is pleased to support the open source community by making RapidJSON available.
-// 
+//
 // Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip. All rights reserved.
 //
 // Licensed under the MIT License (the "License"); you may not use this file except
@@ -7,9 +7,9 @@
 //
 // http://opensource.org/licenses/MIT
 //
-// Unless required by applicable law or agreed to in writing, software distributed 
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
 #ifndef RAPIDJSON_PRETTYWRITER_H_
@@ -31,10 +31,16 @@ RAPIDJSON_NAMESPACE_BEGIN
     \tparam TargetEncoding Encoding of output stream.
     \tparam StackAllocator Type of allocator for allocating memory of stack.
 */
-template<typename OutputStream, typename SourceEncoding = UTF8<>, typename TargetEncoding = UTF8<>, typename StackAllocator = CrtAllocator>
-class PrettyWriter : public Writer<OutputStream, SourceEncoding, TargetEncoding, StackAllocator> {
+template<typename OUTPUTSTREAM, typename SOURCEENCODING = UTF8<>, typename TARGETENCODING = UTF8<>, typename STACKALLOCATOR = CrtAllocator>
+  class PrettyWriter : public WriterBase< PrettyWriter<OUTPUTSTREAM, SOURCEENCODING, TARGETENCODING, STACKALLOCATOR>,
+                                          OUTPUTSTREAM, SOURCEENCODING, TARGETENCODING, STACKALLOCATOR > {
 public:
-    typedef Writer<OutputStream, SourceEncoding, TargetEncoding, StackAllocator> Base;
+    typedef WriterBase<PrettyWriter<OUTPUTSTREAM, SOURCEENCODING, TARGETENCODING, STACKALLOCATOR>,
+                       OUTPUTSTREAM, SOURCEENCODING, TARGETENCODING, STACKALLOCATOR> Base;
+    typedef OUTPUTSTREAM OutputStream;
+    typedef SOURCEENCODING SourceEncoding;
+    typedef TARGETENCODING TargetEncoding;
+    typedef STACKALLOCATOR StackAllocator;
     typedef typename Base::Ch Ch;
 
     //! Constructor
@@ -42,8 +48,10 @@ public:
         \param allocator User supplied allocator. If it is null, it will create a private one.
         \param levelDepth Initial capacity of stack.
     */
-    PrettyWriter(OutputStream& os, StackAllocator* allocator = 0, size_t levelDepth = Base::kDefaultLevelDepth) : 
-        Base(os, allocator, levelDepth), indentChar_(' '), indentCharCount_(4) {}
+    PrettyWriter(OutputStream& os, StackAllocator* allocator = 0, size_t levelDepth = Base::kDefaultLevelDepth)
+      : Base(os, allocator, levelDepth), indentChar_(' '), indentCharCount_(4)
+    {
+    }
 
     //! Set custom indentation.
     /*! \param indentChar       Character for indentation. Must be whitespace character (' ', '\\t', '\\n', '\\r').
@@ -57,93 +65,15 @@ public:
         return *this;
     }
 
-    /*! @name Implementation of Handler
-        \see Handler
-    */
-    //@{
 
-    bool Null()                 { PrettyPrefix(kNullType);   return Base::WriteNull(); }
-    bool Bool(bool b)           { PrettyPrefix(b ? kTrueType : kFalseType); return Base::WriteBool(b); }
-    bool Int(int i)             { PrettyPrefix(kNumberType); return Base::WriteInt(i); }
-    bool Uint(unsigned u)       { PrettyPrefix(kNumberType); return Base::WriteUint(u); }
-    bool Int64(int64_t i64)     { PrettyPrefix(kNumberType); return Base::WriteInt64(i64); }
-    bool Uint64(uint64_t u64)   { PrettyPrefix(kNumberType); return Base::WriteUint64(u64);  }
-    bool Double(double d)       { PrettyPrefix(kNumberType); return Base::WriteDouble(d); }
-
-    bool String(const Ch* str, SizeType length, bool copy = false) {
-        (void)copy;
-        PrettyPrefix(kStringType);
-        return Base::WriteString(str, length);
-    }
-
-#if RAPIDJSON_HAS_STDSTRING
-    bool String(const std::basic_string<Ch>& str) {
-        return String(str.data(), SizeType(str.size()));
-    }
-#endif
-
-    bool StartObject() {
-        PrettyPrefix(kObjectType);
-        new (Base::level_stack_.template Push<typename Base::Level>()) typename Base::Level(false);
-        return Base::WriteStartObject();
-    }
-
-    bool Key(const Ch* str, SizeType length, bool copy = false) { return String(str, length, copy); }
-	
-    bool EndObject(SizeType memberCount = 0) {
-        (void)memberCount;
-        RAPIDJSON_ASSERT(Base::level_stack_.GetSize() >= sizeof(typename Base::Level));
-        RAPIDJSON_ASSERT(!Base::level_stack_.template Top<typename Base::Level>()->inArray);
-        bool empty = Base::level_stack_.template Pop<typename Base::Level>(1)->valueCount == 0;
-
-        if (!empty) {
-            Base::os_->Put('\n');
-            WriteIndent();
-        }
-        bool ret = Base::WriteEndObject();
-        (void)ret;
-        RAPIDJSON_ASSERT(ret == true);
-        if (Base::level_stack_.Empty()) // end of json text
-            Base::os_->Flush();
-        return true;
-    }
-
-    bool StartArray() {
-        PrettyPrefix(kArrayType);
-        new (Base::level_stack_.template Push<typename Base::Level>()) typename Base::Level(true);
-        return Base::WriteStartArray();
-    }
-
-    bool EndArray(SizeType memberCount = 0) {
-        (void)memberCount;
-        RAPIDJSON_ASSERT(Base::level_stack_.GetSize() >= sizeof(typename Base::Level));
-        RAPIDJSON_ASSERT(Base::level_stack_.template Top<typename Base::Level>()->inArray);
-        bool empty = Base::level_stack_.template Pop<typename Base::Level>(1)->valueCount == 0;
-
-        if (!empty) {
-            Base::os_->Put('\n');
-            WriteIndent();
-        }
-        bool ret = Base::WriteEndArray();
-        (void)ret;
-        RAPIDJSON_ASSERT(ret == true);
-        if (Base::level_stack_.Empty()) // end of json text
-            Base::os_->Flush();
-        return true;
-    }
-
-    //@}
-
-    /*! @name Convenience extensions */
-    //@{
-
-    //! Simpler but slower overload.
-    bool String(const Ch* str) { return String(str, internal::StrLen(str)); }
-    bool Key(const Ch* str) { return Key(str, internal::StrLen(str)); }
-
-    //@}
 protected:
-    void PrettyPrefix(Type type) {
+    friend class WriterBase<PrettyWriter<OUTPUTSTREAM, SOURCEENCODING, TARGETENCODING, STACKALLOCATOR>, OUTPUTSTREAM, SOURCEENCODING, TARGETENCODING, STACKALLOCATOR >;
+
+    using Base::level_stack_;
+    using Base::os_;
+    using Base::hasRoot_;
+
+    void Prefix(Type type) {
         (void)type;
         if (Base::level_stack_.GetSize() != 0) { // this value is not at root
             typename Base::Level* level = Base::level_stack_.template Top<typename Base::Level>();
@@ -182,6 +112,16 @@ protected:
             RAPIDJSON_ASSERT(!Base::hasRoot_);  // Should only has one and only one root.
             Base::hasRoot_ = true;
         }
+    }
+
+    void CloseBlock()
+    {
+      bool empty = Base::level_stack_.template Pop<typename Base::Level>(1)->valueCount == 0;
+
+      if (!empty) {
+        Base::os_->Put('\n');
+        WriteIndent();
+      }
     }
 
     void WriteIndent()  {

--- a/include/rapidjson/prettywriter.h
+++ b/include/rapidjson/prettywriter.h
@@ -1,6 +1,6 @@
 // Tencent is pleased to support the open source community by making RapidJSON available.
 //
-// Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip. All rights reserved.
+// Copyright (C) 2015 THL A29 Limited, a Tencent company, Milo Yip and Bruno Nicoletti. All rights reserved.
 //
 // Licensed under the MIT License (the "License"); you may not use this file except
 // in compliance with the License. You may obtain a copy of the License at

--- a/include/rapidjson/writer.h
+++ b/include/rapidjson/writer.h
@@ -1,6 +1,6 @@
 // Tencent is pleased to support the open source community by making RapidJSON available.
 //
-// Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip. All rights reserved.
+// Copyright (C) 2015 THL A29 Limited, a Tencent company, Milo Yip and Bruno Nicoletti. All rights reserved.
 //
 // Licensed under the MIT License (the "License"); you may not use this file except
 // in compliance with the License. You may obtain a copy of the License at

--- a/include/rapidjson/writer.h
+++ b/include/rapidjson/writer.h
@@ -33,6 +33,11 @@ RAPIDJSON_DIAG_PUSH
 RAPIDJSON_DIAG_OFF(4127) // conditional expression is constant
 #endif
 
+#ifdef __GNUC__
+RAPIDJSON_DIAG_PUSH
+RAPIDJSON_DIAG_OFF(effc++)
+#endif
+
 RAPIDJSON_NAMESPACE_BEGIN
 
 //! JSON writer
@@ -177,6 +182,10 @@ inline bool WriterBase<Writer<StringBuffer>, StringBuffer>::WriteDouble(double d
 RAPIDJSON_NAMESPACE_END
 
 #ifdef _MSC_VER
+RAPIDJSON_DIAG_POP
+#endif
+
+#ifdef __GNUC__
 RAPIDJSON_DIAG_POP
 #endif
 

--- a/include/rapidjson/writerbase.h
+++ b/include/rapidjson/writerbase.h
@@ -1,8 +1,6 @@
 // Tencent is pleased to support the open source community by making RapidJSON available.
 //
-// Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip. All rights reserved.
-//
-// Additional modifcations, Copyright (C) 2015, Bruno Nicoletti. All rights reserved.
+// Copyright (C) 2015 THL A29 Limited, a Tencent company, Milo Yip and Bruno Nicoletti. All rights reserved.
 //
 // Licensed under the MIT License (the "License"); you may not use this file except
 // in compliance with the License. You may obtain a copy of the License at

--- a/include/rapidjson/writerbase.h
+++ b/include/rapidjson/writerbase.h
@@ -375,6 +375,49 @@ public:
     }
 #endif
 
+  /// Functor to output the given bool value
+    bool operator()(bool b)
+    {
+      return Bool(b);
+    }
+
+    /// Functor to output the given int value
+    bool operator()(int i)
+    {
+      return Int(i);
+    }
+
+    /// Functor to output the given unsigned int value
+    bool operator()(unsigned u)
+    {
+      return Uint(u);
+    }
+
+    /// Functor to output the given 64 bit int value
+    bool operator()(int64_t i64)
+    {
+      return Int64(i64);
+    }
+
+    /// Functor to output the given 64 bit int value.
+    bool operator()(uint64_t u64)
+    {
+      return Uint64(u64);
+    }
+
+    /// Functor to output the given double value.
+    bool operator()(double d)
+    {
+      return Double(d);
+    }
+
+    /// Functor to output the given string.
+    template<typename STRING>
+    bool operator()(STRING &s)
+    {
+      return String(s);
+    }
+
     /// Functor to output the given key with a bool value
     template<typename STRING>
     bool operator()(const STRING &key, bool b)

--- a/include/rapidjson/writerbase.h
+++ b/include/rapidjson/writerbase.h
@@ -325,8 +325,7 @@ public:
     template<class STRING>
     ObjectBlock<Derived> Object(const String &key)
     {
-      Key(key);
-      return std::move(ObjectBlock<Derived>(*DerivedThis()));
+      return std::move(ObjectBlock<Derived>(*DerivedThis(), key));
     }
 #endif
 
@@ -373,8 +372,7 @@ public:
     template<class STRING>
     ArrayBlock<Derived> Array(const String &key)
     {
-      Key(key);
-      return std::move(ArrayBlock<Derived>(*DerivedThis()));
+      return std::move(ArrayBlock<Derived>(*DerivedThis(), key));
     }
 #endif
 

--- a/include/rapidjson/writerbase.h
+++ b/include/rapidjson/writerbase.h
@@ -21,7 +21,6 @@
 #include "internal/strfunc.h"
 #include "internal/dtoa.h"
 #include "internal/itoa.h"
-#include "stringbuffer.h"
 
 #if __cplusplus >= 201103
 #include "autoblocks.h"

--- a/include/rapidjson/writerbase.h
+++ b/include/rapidjson/writerbase.h
@@ -1,0 +1,433 @@
+// Tencent is pleased to support the open source community by making RapidJSON available.
+//
+// Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip. All rights reserved.
+//
+// Additional modifcations, Copyright (C) 2015, Bruno Nicoletti. All rights reserved.
+//
+// Licensed under the MIT License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://opensource.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#ifndef RAPIDJSON_WRITERBASE_H_
+#define RAPIDJSON_WRITERBASE_H_
+
+#include "rapidjson.h"
+#include "internal/stack.h"
+#include "internal/strfunc.h"
+#include "internal/dtoa.h"
+#include "internal/itoa.h"
+#include "stringbuffer.h"
+#include <new>      // placement new
+
+#if RAPIDJSON_HAS_STDSTRING
+#include <string>
+#endif
+
+#ifdef _MSC_VER
+RAPIDJSON_DIAG_PUSH
+RAPIDJSON_DIAG_OFF(4127) // conditional expression is constant
+#endif
+
+RAPIDJSON_NAMESPACE_BEGIN
+
+//! JSON writer
+/*! Writer implements the concept Handler.
+    It generates JSON text by events to an output os.
+
+    User may programmatically calls the functions of a writer to generate JSON text.
+
+    On the other side, a writer can also be passed to objects that generates events,
+
+    for example Reader::Parse() and Document::Accept().
+
+    \tparam OutputStream Type of output stream.
+    \tparam SourceEncoding Encoding of source string.
+    \tparam TargetEncoding Encoding of output stream.
+    \tparam StackAllocator Type of allocator for allocating memory of stack.
+    \note implements Handler concept
+*/
+template<class DERIVED,
+         typename OUTPUTSTREAM,
+         typename SOURCEENCODING = UTF8<>,
+         typename TARGETENCODING = UTF8<>,
+         typename STACKALLOCATOR = CrtAllocator>
+class WriterBase {
+public:
+    typedef DERIVED Derived;
+    typedef OUTPUTSTREAM OutputStream;
+    typedef SOURCEENCODING SourceEncoding;
+    typedef TARGETENCODING TargetEncoding;
+    typedef STACKALLOCATOR StackAllocator;
+    typedef typename SourceEncoding::Ch Ch;
+
+    //! Constructor
+    /*! \param os Output stream.
+        \param stackAllocator User supplied allocator. If it is null, it will create a private one.
+        \param levelDepth Initial capacity of stack.
+    */
+    explicit
+    WriterBase(OutputStream& os, StackAllocator* stackAllocator = 0, size_t levelDepth = kDefaultLevelDepth) :
+        os_(&os), level_stack_(stackAllocator, levelDepth * sizeof(Level)), hasRoot_(false) {}
+
+    explicit
+    WriterBase(StackAllocator* allocator = 0, size_t levelDepth = kDefaultLevelDepth) :
+        os_(0), level_stack_(allocator, levelDepth * sizeof(Level)), hasRoot_(false) {}
+
+    //! Reset the writer with a new stream.
+    /*!
+        This function reset the writer with a new stream and default settings,
+        in order to make a WriterBase object reusable for output multiple JSONs.
+
+        \param os New output stream.
+        \code
+        WriterBase<OutputStream> writer(os1);
+        writer.StartObject();
+        // ...
+        writer.EndObject();
+
+        writer.Reset(os2);
+        writer.StartObject();
+        // ...
+        writer.EndObject();
+        \endcode
+    */
+    void Reset(OutputStream& os) {
+        os_ = &os;
+        hasRoot_ = false;
+        level_stack_.Clear();
+    }
+
+    //! Checks whether the output is a complete JSON.
+    /*!
+        A complete JSON has a complete root object or array.
+    */
+    bool IsComplete() const {
+        return hasRoot_ && level_stack_.Empty();
+    }
+
+    /// \brief Output a 'null' to the JSON stream.
+    ///
+    ///  \return Whether it is succeed.
+    bool Null()
+    {
+       DerivedPrefix(kNullType);
+       return WriteNull();
+    }
+
+    /// \brief Output the given bool value to the JSON stream.
+    bool Bool(bool b)
+    {
+       DerivedPrefix(b ? kTrueType : kFalseType);
+       return WriteBool(b);
+    }
+
+    /// \brief Output the given integer value to the JSON stream.
+    ///
+    ///  \return Whether it is succeed.
+    bool Int(int i)
+    {
+      DerivedPrefix(kNumberType);
+      return WriteInt(i);
+    }
+
+    /// \brief Output the given unsigned integer value to the JSON stream.
+    ///
+    ///  \return Whether it is succeed.
+    bool Uint(unsigned u)
+    {
+      DerivedPrefix(kNumberType);
+      return WriteUint(u);
+    }
+
+    /// \brief Output the given signed 64 bit integer value to the JSON stream.
+    ///
+    ///  \return Whether it is succeed.
+    bool Int64(int64_t i64)
+    {
+      DerivedPrefix(kNumberType);
+      return WriteInt64(i64);
+    }
+
+    /// \brief Output the given unsigned 64 bit integer value to the JSON stream.
+    ///
+    ///  \return Whether it is succeed.
+    bool Uint64(uint64_t u64)
+    {
+      DerivedPrefix(kNumberType);
+      return WriteUint64(u64);
+    }
+
+    /// \brief Output the given \c double value to the JSON stream.
+    ///
+    ///  \return Whether it is succeed.
+    bool Double(double d)
+    {
+      DerivedPrefix(kNumberType);
+      return WriteDouble(d);
+    }
+
+    /// \brief Output the given value string of the given length value to the JSON stream.
+    ///
+    ///  \return Whether it is succeed.
+    bool String(const Ch* str, SizeType length, bool copy = false)
+    {
+      (void)copy;
+      DerivedPrefix(kStringType);
+      return WriteString(str, length);
+    }
+
+    /// \brief Output the given string to the JSON stream. The length is determined by strlen.
+    ///
+    ///  \return Whether it is succeed.
+    bool String(const Ch* str)
+    {
+      return String(str, internal::StrLen(str));
+    }
+
+#if RAPIDJSON_HAS_STDSTRING
+    /// \brief Output the given string to the JSON stream. The length is determined by strlen.
+    ///
+    ///  \return Whether it is succeed.
+    bool String(const std::string &str)
+    {
+      return String(str.data(), str.size());
+    }
+#endif
+
+    /// \brief Output the given key of the given length value to the JSON stream.
+    ///
+    ///  \return Whether it is succeed.
+    bool Key(const Ch* str, SizeType length, bool copy = false)
+    {
+      return String(str, length, copy);
+    }
+
+    /// \brief Output the given key to the JSON stream. The length is determined by strlen.
+    ///
+    ///  \return Whether it is succeed.
+    bool Key(const Ch* str)
+    {
+      return Key(str, internal::StrLen(str));
+    }
+
+    /// \brief Start a JSON compound object on the stream.
+    ///
+    ///  \return Whether it is succeed.
+    bool StartObject()
+    {
+      DerivedPrefix(kObjectType);
+      new (level_stack_.template Push<Level>()) Level(false);
+      return WriteStartObject();
+    }
+
+    /// \brief End the currently open JSON compound object on the stream.
+    ///
+    ///  \return Whether it is succeed.
+    bool EndObject(SizeType memberCount = 0)
+    {
+        (void)memberCount;
+        RAPIDJSON_ASSERT(level_stack_.GetSize() >= sizeof(Level));
+        RAPIDJSON_ASSERT(!level_stack_.template Top<Level>()->inArray);
+        DerivedCloseBlock();
+        bool ret = WriteEndObject();
+        if (level_stack_.Empty())   // end of json text
+            os_->Flush();
+        return ret;
+    }
+
+    /// \brief Start a JSON array on the stream.
+    ///
+    ///  \return Whether it is succeed.
+    bool StartArray() {
+        DerivedPrefix(kArrayType);
+        new (level_stack_.template Push<Level>()) Level(true);
+        return WriteStartArray();
+    }
+
+    /// \brief End the currently open JSON array object on the stream.
+    ///
+    ///  \return Whether it is succeed.
+    bool EndArray(SizeType elementCount = 0)
+    {
+        (void)elementCount;
+        RAPIDJSON_ASSERT(level_stack_.GetSize() >= sizeof(Level));
+        RAPIDJSON_ASSERT(level_stack_.template Top<Level>()->inArray);
+        DerivedCloseBlock();
+        bool ret = WriteEndArray();
+        if (level_stack_.Empty())   // end of json text
+            os_->Flush();
+        return ret;
+    }
+
+protected:
+    //! Information for each nested level
+    struct Level {
+        Level(bool inArray_) : valueCount(0), inArray(inArray_) {}
+        size_t valueCount;  //!< number of values in this level
+        bool inArray;       //!< true if in array, otherwise in object
+    };
+
+    static const size_t kDefaultLevelDepth = 32;
+
+    bool WriteNull()  {
+        os_->Put('n'); os_->Put('u'); os_->Put('l'); os_->Put('l'); return true;
+    }
+
+    bool WriteBool(bool b)  {
+        if (b) {
+            os_->Put('t'); os_->Put('r'); os_->Put('u'); os_->Put('e');
+        }
+        else {
+            os_->Put('f'); os_->Put('a'); os_->Put('l'); os_->Put('s'); os_->Put('e');
+        }
+        return true;
+    }
+
+    bool WriteInt(int i) {
+        char buffer[11];
+        const char* end = internal::i32toa(i, buffer);
+        for (const char* p = buffer; p != end; ++p)
+            os_->Put(*p);
+        return true;
+    }
+
+    bool WriteUint(unsigned u) {
+        char buffer[10];
+        const char* end = internal::u32toa(u, buffer);
+        for (const char* p = buffer; p != end; ++p)
+            os_->Put(*p);
+        return true;
+    }
+
+    bool WriteInt64(int64_t i64) {
+        char buffer[21];
+        const char* end = internal::i64toa(i64, buffer);
+        for (const char* p = buffer; p != end; ++p)
+            os_->Put(*p);
+        return true;
+    }
+
+    bool WriteUint64(uint64_t u64) {
+        char buffer[20];
+        char* end = internal::u64toa(u64, buffer);
+        for (char* p = buffer; p != end; ++p)
+            os_->Put(*p);
+        return true;
+    }
+
+    bool WriteDouble(double d) {
+        char buffer[25];
+        char* end = internal::dtoa(d, buffer);
+        for (char* p = buffer; p != end; ++p)
+            os_->Put(*p);
+        return true;
+    }
+
+    bool WriteString(const Ch* str, SizeType length)  {
+        static const char hexDigits[16] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
+        static const char escape[256] = {
+#define Z16 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+            //0    1    2    3    4    5    6    7    8    9    A    B    C    D    E    F
+            'u', 'u', 'u', 'u', 'u', 'u', 'u', 'u', 'b', 't', 'n', 'u', 'f', 'r', 'u', 'u', // 00
+            'u', 'u', 'u', 'u', 'u', 'u', 'u', 'u', 'u', 'u', 'u', 'u', 'u', 'u', 'u', 'u', // 10
+              0,   0, '"',   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0, // 20
+            Z16, Z16,                                                                       // 30~4F
+              0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,'\\',   0,   0,   0, // 50
+            Z16, Z16, Z16, Z16, Z16, Z16, Z16, Z16, Z16, Z16                                // 60~FF
+#undef Z16
+        };
+
+        os_->Put('\"');
+        GenericStringStream<SourceEncoding> is(str);
+        while (is.Tell() < length) {
+            const Ch c = is.Peek();
+            if (!TargetEncoding::supportUnicode && (unsigned)c >= 0x80) {
+                // Unicode escaping
+                unsigned codepoint;
+                if (!SourceEncoding::Decode(is, &codepoint))
+                    return false;
+                os_->Put('\\');
+                os_->Put('u');
+                if (codepoint <= 0xD7FF || (codepoint >= 0xE000 && codepoint <= 0xFFFF)) {
+                    os_->Put(hexDigits[(codepoint >> 12) & 15]);
+                    os_->Put(hexDigits[(codepoint >>  8) & 15]);
+                    os_->Put(hexDigits[(codepoint >>  4) & 15]);
+                    os_->Put(hexDigits[(codepoint      ) & 15]);
+                }
+                else {
+                    RAPIDJSON_ASSERT(codepoint >= 0x010000 && codepoint <= 0x10FFFF);
+                    // Surrogate pair
+                    unsigned s = codepoint - 0x010000;
+                    unsigned lead = (s >> 10) + 0xD800;
+                    unsigned trail = (s & 0x3FF) + 0xDC00;
+                    os_->Put(hexDigits[(lead >> 12) & 15]);
+                    os_->Put(hexDigits[(lead >>  8) & 15]);
+                    os_->Put(hexDigits[(lead >>  4) & 15]);
+                    os_->Put(hexDigits[(lead      ) & 15]);
+                    os_->Put('\\');
+                    os_->Put('u');
+                    os_->Put(hexDigits[(trail >> 12) & 15]);
+                    os_->Put(hexDigits[(trail >>  8) & 15]);
+                    os_->Put(hexDigits[(trail >>  4) & 15]);
+                    os_->Put(hexDigits[(trail      ) & 15]);
+                }
+            }
+            else if ((sizeof(Ch) == 1 || (unsigned)c < 256) && escape[(unsigned char)c])  {
+                is.Take();
+                os_->Put('\\');
+                os_->Put(escape[(unsigned char)c]);
+                if (escape[(unsigned char)c] == 'u') {
+                    os_->Put('0');
+                    os_->Put('0');
+                    os_->Put(hexDigits[(unsigned char)c >> 4]);
+                    os_->Put(hexDigits[(unsigned char)c & 0xF]);
+                }
+            }
+            else
+                if (!Transcoder<SourceEncoding, TargetEncoding>::Transcode(is, *os_))
+                    return false;
+        }
+        os_->Put('\"');
+        return true;
+    }
+
+    bool WriteStartObject() { os_->Put('{'); return true; }
+    bool WriteEndObject()   { os_->Put('}'); return true; }
+    bool WriteStartArray()  { os_->Put('['); return true; }
+    bool WriteEndArray()    { os_->Put(']'); return true; }
+
+    OutputStream* os_;
+    internal::Stack<StackAllocator> level_stack_;
+    bool hasRoot_;
+
+    // Calls the Prefix function in derived version of this.
+    void DerivedPrefix(Type type)
+    {
+      static_cast<Derived *>(this)->Prefix(type);
+    }
+
+    // Calls the Prefix function in derived version of this.
+    void DerivedCloseBlock()
+    {
+      static_cast<Derived *>(this)->CloseBlock();
+    }
+
+private:
+    // Prohibit copy constructor & assignment operator.
+    WriterBase(const WriterBase&);
+    WriterBase& operator=(const WriterBase&);
+};
+
+RAPIDJSON_NAMESPACE_END
+
+#ifdef _MSC_VER
+RAPIDJSON_DIAG_POP
+#endif
+
+#endif // RAPIDJSON_RAPIDJSON_H_

--- a/readme.md
+++ b/readme.md
@@ -2,11 +2,13 @@
 
 ![](https://img.shields.io/badge/release-v1.0.2-blue.png)
 
-## A fast JSON parser/generator for C++ with both SAX/DOM style API 
+## A fast JSON parser/generator for C++ with both SAX/DOM style API
 
 Tencent is pleased to support the open source community by making RapidJSON available.
 
 Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip. All rights reserved.
+
+Some contributions are additionally Copyright (C) 2015 Bruno Nicoletti. All rights reserved. See individual files for details.
 
 * [RapidJSON GitHub](https://github.com/miloyip/rapidjson/)
 * RapidJSON Documentation

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(UNITTEST_SOURCES
-	allocatorstest.cpp
+  allocatorstest.cpp
     bigintegertest.cpp
     documenttest.cpp
     encodedstreamtest.cpp
@@ -11,12 +11,13 @@ set(UNITTEST_SOURCES
     pointertest.cpp
     prettywritertest.cpp
     readertest.cpp
-	simdtest.cpp
+  simdtest.cpp
     stringbuffertest.cpp
     strtodtest.cpp
     unittest.cpp
     valuetest.cpp
-    writertest.cpp)
+    writertest.cpp
+    writerstringliteraltest.cpp)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall -Wextra -Weffc++ -Wswitch-default -Wfloat-equal")

--- a/test/unittest/unittest.h
+++ b/test/unittest/unittest.h
@@ -1,5 +1,5 @@
 // Tencent is pleased to support the open source community by making RapidJSON available.
-// 
+//
 // Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip. All rights reserved.
 //
 // Licensed under the MIT License (the "License"); you may not use this file except
@@ -7,14 +7,17 @@
 //
 // http://opensource.org/licenses/MIT
 //
-// Unless required by applicable law or agreed to in writing, software distributed 
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
 #ifndef UNITTEST_H_
 #define UNITTEST_H_
 
+// Can't get the writer string literal unit test to work unless this is enabled across
+// all compilation units. Bruno Nicoletti
+#define RAPIDJSON_UNIT_TEST_STRING_LITERALS
 
 // gtest indirectly included inttypes.h, without __STDC_CONSTANT_MACROS.
 #ifndef __STDC_CONSTANT_MACROS
@@ -70,7 +73,7 @@ inline FILE* TempFile(char *filename) {
     if (filename[0] == '\\')
         for (int i = 0; filename[i] != '\0'; i++)
             filename[i] = filename[i + 1];
-        
+
     return fopen(filename, "wb");
 #else
     strcpy(filename, "/tmp/fileXXXXXX");

--- a/test/unittest/writerstringliteraltest.cpp
+++ b/test/unittest/writerstringliteraltest.cpp
@@ -1,0 +1,50 @@
+// Copyright (C) 2015 Bruno Nicoletti. All rights reserved.
+//
+// Licensed under the MIT License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://opensource.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#ifndef RAPIDJSON_HAS_STDSTRING
+#define RAPIDJSON_HAS_STDSTRING
+#endif
+
+#include "unittest.h"
+#include "rapidjson/writer.h"
+
+using namespace rapidjson;
+
+TEST(StringLiterals, IsCallingStringLiterals)
+{
+  // Unless this is enabled across all translation units
+  // the unit test wont work. The linker appears to be eliding
+  // versions compiled into this translation unit in favour of
+  // others. Poo.
+#ifdef RAPIDJSON_UNIT_TEST_STRING_LITERALS
+  StringBuffer buffer;
+  Writer<StringBuffer> writer(buffer);
+  writer.StartObject();
+
+  writer.String("banana");
+  EXPECT_EQ(writer.lastStringCallWasToStringLiteralVersion(), true);
+
+  const char *str2 = strdup("oranges");
+  writer.String(str2);
+  EXPECT_EQ(writer.lastStringCallWasToStringLiteralVersion(), false);
+  free((void*)str2);
+
+  std::string str3("pears");
+  writer.String(str3);
+  EXPECT_EQ(writer.lastStringCallWasToStringLiteralVersion(), false);
+
+  writer.String("grapes");
+  EXPECT_EQ(writer.lastStringCallWasToStringLiteralVersion(), true);
+
+  writer.EndObject();
+#endif
+}

--- a/test/unittest/writerstringliteraltest.cpp
+++ b/test/unittest/writerstringliteraltest.cpp
@@ -1,4 +1,6 @@
-// Copyright (C) 2015 Bruno Nicoletti. All rights reserved.
+// Tencent is pleased to support the open source community by making RapidJSON available.
+//
+// Copyright (C) 2015 THL A29 Limited, a Tencent company, Milo Yip and Bruno Nicoletti. All rights reserved.
 //
 // Licensed under the MIT License (the "License"); you may not use this file except
 // in compliance with the License. You may obtain a copy of the License at

--- a/test/unittest/writertest.cpp
+++ b/test/unittest/writertest.cpp
@@ -1,5 +1,5 @@
 // Tencent is pleased to support the open source community by making RapidJSON available.
-// 
+//
 // Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip. All rights reserved.
 //
 // Licensed under the MIT License (the "License"); you may not use this file except
@@ -7,9 +7,9 @@
 //
 // http://opensource.org/licenses/MIT
 //
-// Unless required by applicable law or agreed to in writing, software distributed 
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
 #include "unittest.h"
@@ -164,15 +164,15 @@ private:
 
 TEST(Writer, OStreamWrapper) {
     StringStream s("{ \"hello\" : \"world\", \"t\" : true , \"f\" : false, \"n\": null, \"i\":123, \"pi\": 3.1416, \"a\":[1, 2, 3], \"u64\": 1234567890123456789, \"i64\":-1234567890123456789 } ");
-    
+
     std::stringstream ss;
     OStreamWrapper os(ss);
-    
+
     Writer<OStreamWrapper> writer(os);
 
     Reader reader;
     reader.Parse<0>(s, writer);
-    
+
     std::string actual = ss.str();
     EXPECT_STREQ("{\"hello\":\"world\",\"t\":true,\"f\":false,\"n\":null,\"i\":123,\"pi\":3.1416,\"a\":[1,2,3],\"u64\":1234567890123456789,\"i64\":-1234567890123456789}", actual.c_str());
 }
@@ -366,7 +366,7 @@ TEST(Writer, InvalidEventSequence) {
         EXPECT_FALSE(writer.IsComplete());
     }
 
-    // { 1: 
+    // { 1:
     {
         StringBuffer buffer;
         Writer<StringBuffer> writer(buffer);
@@ -374,4 +374,29 @@ TEST(Writer, InvalidEventSequence) {
         EXPECT_THROW(writer.Int(1), AssertException);
         EXPECT_FALSE(writer.IsComplete());
     }
+}
+
+template<class T>
+void TestKeyValueFunctorType(const T &value, const char *expectedValue)
+{
+  StringBuffer buffer;
+  Writer<StringBuffer> writer(buffer);
+  writer.StartObject();
+  writer("Key", value);
+  writer.EndObject();
+  EXPECT_TRUE(writer.IsComplete());
+  EXPECT_STREQ(expectedValue, buffer.GetString());
+}
+
+TEST(Writer, KeyValueFunctors) {
+  TestKeyValueFunctorType(false, "{\"Key\":false}");
+  TestKeyValueFunctorType(true, "{\"Key\":true}");
+  TestKeyValueFunctorType(-2, "{\"Key\":-2}");
+  TestKeyValueFunctorType(200u, "{\"Key\":200}");
+  TestKeyValueFunctorType(int64_t(-1234567890123456789), "{\"Key\":-1234567890123456789}");
+  TestKeyValueFunctorType(uint64_t(1234567890123456789), "{\"Key\":1234567890123456789}");
+  TestKeyValueFunctorType("banana", "{\"Key\":\"banana\"}");
+  const char *pomegranate = "pomegranate";
+  TestKeyValueFunctorType(pomegranate, "{\"Key\":\"pomegranate\"}");
+  TestKeyValueFunctorType(1.7976931348623157e308, "{\"Key\":1.7976931348623157e308}");
 }

--- a/test/unittest/writertest.cpp
+++ b/test/unittest/writertest.cpp
@@ -1,6 +1,6 @@
 // Tencent is pleased to support the open source community by making RapidJSON available.
 //
-// Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip. All rights reserved.
+// Copyright (C) 2015 THL A29 Limited, a Tencent company, Milo Yip and Bruno Nicoletti. All rights reserved.
 //
 // Licensed under the MIT License (the "License"); you may not use this file except
 // in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
I've gone and done a major refactor on Writer and PrettyWriter. There is now a new base class, **WriterBase**, that both **Writer** and **PrettyWriter** independently inherit from. **Writer** and **PrettyWriter** no longer have any duplicated functions and are much smaller than they were. The only functions left in the old two writer classes are the old **Prefix** function as well as a new function **CloseBlock**. **WriterBase** uses static polymorphism to call the correct implementation of **Prefix** or **CloseBlock**, and no virtuals are involved. The template signature of WriterBase is pretty ugly though, but you now have much less code to do the same job as before

I've also added overloads for any function that took a **'char *'** as an argument and the can now differentiate between a string literal and a non string literal. For example....

``` C++
void writeThing(WriterType &w, const char *value)
{
   myWriter.Key("thing");  // will call the string literal overload and avoid strlen
   myWriter.String(value); // will call the char * overload and not avoid strlen
}
```

With a string literal, the length is known at compile time and so you can avoid calling 'strlen' on them. The code to do that is slightly funky and needs to be templated, but it works. Should make rapidjson even faster for output.

I've also added functor overloads which write key value pairs, make for less verbose client code. So you can now go....

``` C++
void writePerson(WriterType &myWriter, const Person &person)
{
  myWrite.Key(person.uniqueID());      //< key for object
  myWriter.StartObject();              //< start it
  myWriter("age", person.age());       //< person's age, int
  myWriter("name", person.name());     //< person's name, a std::string
  myWriter("height", person.height()); //< person's height, a double
  myWriter.EndObject();                //< close the object
}
```

None of this needs STL or std::strings to work, though I've left the old std::string overloads in there as well as the #ifdef statements to control them. It all passes the current unit tests as well as a few more I've written.

Finally, I've added autoscoping of arrays and blocks. To work best it needs C++11, but can work without (I have a #if  that checks for the C++ version to control it). This is in the new file 'autoblocks.h'. For my last example, you would go...

``` c++
void writePerson(WriterType &myWriter, const Person &person)
{
  rapidjson::ObjectBlock<WriterType> obj(myWriter, person.uniqueID());  /// start an object with the given string as a key
  myWriter("age", person.age());       //< person's age, int
  myWriter("name", person.name());     //< person's name, a std::string
  myWriter("height", person.height()); //< person's height, a double
                                       // object is automatically closed on exit of the scope
}
```

The verbosity of this can be slightly reduced in C++ 11 with use of auto the new **Block** function in **WriterBase**. Useful if you aren't able to have the 'using rapidjson' statement. This is enabled only for C++11 and is of trivial cost and doesn't add any extra dependencies.

``` c++
void writePerson(WriterType &myWriter, const Person &person)
{
  auto obj = myWriter.Block(person.uniqueID());  /// the writer returns the auto block for an object given a key
  myWriter("age", person.age());       //< person's age, int
  myWriter("name", person.name());     //< person's name, a std::string
  myWriter("height", person.height()); //< person's height, a double
                                       // object is automatically closed on exit of the scope
}
```

The automatic blocking for Arrays and Objects has not had a unit test written yet. Tomorrow. The rest is good to go however.

I should also tidy up the comments slightly to bring back some of the doxygen comments I've moved around.

Let me know what you think.
