### PR TITLE
Keep Document value unchanged on parse error, fixes #437

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -1886,14 +1886,13 @@ public:
     */
     template <unsigned parseFlags, typename SourceEncoding, typename InputStream>
     GenericDocument& ParseStream(InputStream& is) {
-        ValueType::SetNull(); // Remove existing root if exist
         GenericReader<SourceEncoding, Encoding, StackAllocator> reader(
             stack_.HasAllocator() ? &stack_.GetAllocator() : 0);
         ClearStackOnExit scope(*this);
         parseResult_ = reader.template Parse<parseFlags>(is, *this);
         if (parseResult_) {
             RAPIDJSON_ASSERT(stack_.GetSize() == sizeof(ValueType)); // Got one and only one root object
-            this->RawAssign(*stack_.template Pop<ValueType>(1));    // Add this-> to prevent issue 13.
+            ValueType::operator=(*stack_.template Pop<ValueType>(1));// Move value from stack to document
         }
         return *this;
     }

--- a/test/unittest/documenttest.cpp
+++ b/test/unittest/documenttest.cpp
@@ -95,6 +95,21 @@ TEST(Document, Parse) {
     ParseTest<CrtAllocator, CrtAllocator>();
 }
 
+TEST(Document, UnchangedOnParseError) {
+    Document doc;
+    doc.SetArray().PushBack(0, doc.GetAllocator());
+
+    doc.Parse("{]");
+    EXPECT_TRUE(doc.HasParseError());
+    EXPECT_TRUE(doc.IsArray());
+    EXPECT_EQ(doc.Size(), 1u);
+
+    doc.Parse("{}");
+    EXPECT_FALSE(doc.HasParseError());
+    EXPECT_TRUE(doc.IsObject());
+    EXPECT_EQ(doc.MemberCount(), 0u);
+}
+
 static FILE* OpenEncodedFile(const char* filename) {
     const char *paths[] = {
         "encodings/%s",


### PR DESCRIPTION
Keeping the DOM unchanged in case of an error is the intended behaviour according to the [documentation] [1].

Instead of forcing the value to `kNullType` before starting the parsing, store the parsed value upon success via regular move.

[1]: https://miloyip.github.io/rapidjson/md_doc_dom.html#ParseError