### PR TITLE
documenttest.cpp: EXPECT_THROW when checking empty allocator (closes #469)

### DIFF
--- a/test/unittest/documenttest.cpp
+++ b/test/unittest/documenttest.cpp
@@ -381,7 +381,7 @@ TYPED_TEST(DocumentMove, MoveConstructor) {
     EXPECT_TRUE(a.IsNull());
     EXPECT_TRUE(b.IsArray());
     EXPECT_EQ(3u, b.Size());
-    EXPECT_EQ(&a.GetAllocator(), (void*)0);
+    EXPECT_THROW(a.GetAllocator(), AssertException);
     EXPECT_EQ(&b.GetAllocator(), &allocator);
 
     b.Parse("{\"Foo\": \"Bar\", \"Baz\": 42}");
@@ -394,7 +394,7 @@ TYPED_TEST(DocumentMove, MoveConstructor) {
     EXPECT_TRUE(b.IsNull());
     EXPECT_TRUE(c.IsObject());
     EXPECT_EQ(2u, c.MemberCount());
-    EXPECT_EQ(&b.GetAllocator(), (void*)0);
+    EXPECT_THROW(b.GetAllocator(), AssertException);
     EXPECT_EQ(&c.GetAllocator(), &allocator);
 }
 
@@ -475,7 +475,7 @@ TYPED_TEST(DocumentMove, MoveAssignment) {
     EXPECT_TRUE(a.IsNull());
     EXPECT_TRUE(b.IsArray());
     EXPECT_EQ(3u, b.Size());
-    EXPECT_EQ(&a.GetAllocator(), (void*)0);
+    EXPECT_THROW(a.GetAllocator(), AssertException);
     EXPECT_EQ(&b.GetAllocator(), &allocator);
 
     b.Parse("{\"Foo\": \"Bar\", \"Baz\": 42}");
@@ -489,7 +489,7 @@ TYPED_TEST(DocumentMove, MoveAssignment) {
     EXPECT_TRUE(b.IsNull());
     EXPECT_TRUE(c.IsObject());
     EXPECT_EQ(2u, c.MemberCount());
-    EXPECT_EQ(&b.GetAllocator(), (void*)0);
+    EXPECT_THROW(b.GetAllocator(), AssertException);
     EXPECT_EQ(&c.GetAllocator(), &allocator);
 }
 


### PR DESCRIPTION
In the `MoveConstructor`/`MoveAssignment` tests, a check for a `NULL` allocator return has been used to check for the correct moved-from state of a Document. After the merge of #426, the GetAllocator call fails with an assertion, if the allocator of a `GenericDocument` is `NULL`.

Check for the throw, instead of `NULL` in the move-related tests.
Tested with GCC 4.9 on Linux with C++11 enabled.

Reported-by: @woldendans