### PR TITLE
GenericDocument: add implicit conversion to ParseResult

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -1986,6 +1986,17 @@ public:
     //! Get the position of last parsing error in input, 0 otherwise.
     size_t GetErrorOffset() const { return parseResult_.Offset(); }
 
+    //! Implicit conversion to get the last parse result
+    /*! \return \ref ParseResult of the last parse operation
+
+        \code
+          Document doc;
+          ParseResult ok = doc.Parse(json);
+          if (!ok)
+            printf( "JSON parse error: %s (%u)\n", GetParseError_En(ok.Code()), ok.Offset());
+        \endcode
+     */
+    operator ParseResult() const { return parseResult_; }
     //!@}
 
     //! Get the allocator of this document.

--- a/test/unittest/documenttest.cpp
+++ b/test/unittest/documenttest.cpp
@@ -28,6 +28,7 @@ void ParseCheck(DocumentType& doc) {
     typedef typename DocumentType::ValueType ValueType;
 
     EXPECT_FALSE(doc.HasParseError());
+    EXPECT_TRUE((ParseResult)doc);
 
     EXPECT_TRUE(doc.IsObject());
 
@@ -99,13 +100,18 @@ TEST(Document, UnchangedOnParseError) {
     Document doc;
     doc.SetArray().PushBack(0, doc.GetAllocator());
 
-    doc.Parse("{]");
+    ParseResult err = doc.Parse("{]");
     EXPECT_TRUE(doc.HasParseError());
+    EXPECT_EQ(err.Code(), doc.GetParseError());
+    EXPECT_EQ(err.Offset(), doc.GetErrorOffset());
     EXPECT_TRUE(doc.IsArray());
     EXPECT_EQ(doc.Size(), 1u);
 
-    doc.Parse("{}");
+    err = doc.Parse("{}");
     EXPECT_FALSE(doc.HasParseError());
+    EXPECT_FALSE(err.IsError());
+    EXPECT_EQ(err.Code(), doc.GetParseError());
+    EXPECT_EQ(err.Offset(), doc.GetErrorOffset());
     EXPECT_TRUE(doc.IsObject());
     EXPECT_EQ(doc.MemberCount(), 0u);
 }


### PR DESCRIPTION
To simplify the error handling, this pull-request adds an implicit conversion of `GenericDocument` to `ParseResult`, allowing code like (already part of the [documentation] [1]):
````cpp
   ParseResult ok = doc.Parse(json);
   if (!ok) // ...
````
I have been bitten by this error in the docs in the discussion of #479.
Unittests are (slightly) updated as well.

[1]: https://miloyip.github.io/rapidjson/group___r_a_p_i_d_j_s_o_n___e_r_r_o_r_s.html#structrapidjson_1_1_parse_result