### PR TITLE
Add encoding validation option for Writer/PrettyWriter

### DIFF
--- a/include/rapidjson/fwd.h
+++ b/include/rapidjson/fwd.h
@@ -91,8 +91,13 @@ typedef GenericReader<UTF8<char>, UTF8<char>, CrtAllocator> Reader;
 
 // writer.h
 
-template<typename OutputStream, typename SourceEncoding, typename TargetEncoding, typename StackAllocator>
+template<typename OutputStream, typename SourceEncoding, typename TargetEncoding, typename StackAllocator, unsigned writeFlags>
 class Writer;
+
+// prettywriter.h
+
+template<typename OutputStream, typename SourceEncoding, typename TargetEncoding, typename StackAllocator, unsigned writeFlags>
+class PrettyWriter;
 
 // document.h
 

--- a/include/rapidjson/prettywriter.h
+++ b/include/rapidjson/prettywriter.h
@@ -31,8 +31,8 @@ RAPIDJSON_NAMESPACE_BEGIN
     \tparam TargetEncoding Encoding of output stream.
     \tparam StackAllocator Type of allocator for allocating memory of stack.
 */
-template<typename OutputStream, typename SourceEncoding = UTF8<>, typename TargetEncoding = UTF8<>, typename StackAllocator = CrtAllocator>
-class PrettyWriter : public Writer<OutputStream, SourceEncoding, TargetEncoding, StackAllocator> {
+template<typename OutputStream, typename SourceEncoding = UTF8<>, typename TargetEncoding = UTF8<>, typename StackAllocator = CrtAllocator, unsigned writeFlags = kWriteDefaultFlags>
+class PrettyWriter : public Writer<OutputStream, SourceEncoding, TargetEncoding, StackAllocator, writeFlags> {
 public:
     typedef Writer<OutputStream, SourceEncoding, TargetEncoding, StackAllocator> Base;
     typedef typename Base::Ch Ch;
@@ -42,8 +42,12 @@ public:
         \param allocator User supplied allocator. If it is null, it will create a private one.
         \param levelDepth Initial capacity of stack.
     */
-    PrettyWriter(OutputStream& os, StackAllocator* allocator = 0, size_t levelDepth = Base::kDefaultLevelDepth) : 
+    explicit PrettyWriter(OutputStream& os, StackAllocator* allocator = 0, size_t levelDepth = Base::kDefaultLevelDepth) : 
         Base(os, allocator, levelDepth), indentChar_(' '), indentCharCount_(4) {}
+
+
+    explicit PrettyWriter(StackAllocator* allocator = 0, size_t levelDepth = Base::kDefaultLevelDepth) : 
+        Base(allocator, levelDepth), indentChar_(' '), indentCharCount_(4) {}
 
     //! Set custom indentation.
     /*! \param indentChar       Character for indentation. Must be whitespace character (' ', '\\t', '\\n', '\\r').

--- a/test/unittest/fwdtest.cpp
+++ b/test/unittest/fwdtest.cpp
@@ -69,7 +69,10 @@ struct Foo {
     Reader* reader;
 
     // writer.h
-    Writer<StringBuffer, UTF8<char>, UTF8<char>, CrtAllocator>* writer;
+    Writer<StringBuffer, UTF8<char>, UTF8<char>, CrtAllocator, 0>* writer;
+
+    // prettywriter.h
+    PrettyWriter<StringBuffer, UTF8<char>, UTF8<char>, CrtAllocator, 0>* prettywriter;
 
     // document.h
     Value* value;
@@ -94,6 +97,7 @@ struct Foo {
 #include "rapidjson/memorystream.h"
 #include "rapidjson/document.h" // -> reader.h
 #include "rapidjson/writer.h"
+#include "rapidjson/prettywriter.h"
 #include "rapidjson/schema.h"   // -> pointer.h
 
 Foo::Foo() : 
@@ -138,6 +142,9 @@ Foo::Foo() :
 
     // writer.h
     writer(RAPIDJSON_NEW((Writer<StringBuffer>))),
+
+    // prettywriter.h
+    prettywriter(RAPIDJSON_NEW((PrettyWriter<StringBuffer>))),
 
     // document.h
     value(RAPIDJSON_NEW(Value)),
@@ -195,6 +202,9 @@ Foo::~Foo() {
 
     // writer.h
     RAPIDJSON_DELETE(writer);
+
+    // prettywriter.h
+    RAPIDJSON_DELETE(prettywriter);
 
     // document.h
     RAPIDJSON_DELETE(value);


### PR DESCRIPTION
Fix #325 
Also provide future additional enhancement mechanism for `Writer` and `PrettyWriter`.
