### PR TITLE
#562: example: parsebyparts now compiles with g++-4.9

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -20,7 +20,7 @@ include_directories("../include/")
 add_definitions(-D__STDC_FORMAT_MACROS)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall -Wextra -Weffc++ -Wswitch-default")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -Werror -Wall -Wextra -Weffc++ -Wswitch-default")
 elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -lpthread -Werror -Wall -Wextra -Weffc++ -Wswitch-default -Wfloat-equal -Wimplicit-fallthrough -Weverything")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")

--- a/example/parsebyparts/parsebyparts.cpp
+++ b/example/parsebyparts/parsebyparts.cpp
@@ -17,7 +17,15 @@ using namespace rapidjson;
 template<unsigned parseFlags = kParseDefaultFlags>
 class AsyncDocumentParser {
 public:
-    AsyncDocumentParser(Document& d) : stream_(*this), d_(d), parseThread_(&AsyncDocumentParser::Parse, this), completed_() {}
+    AsyncDocumentParser(Document& d)
+        : stream_(*this)
+        , d_(d)
+        , parseThread_(&AsyncDocumentParser::Parse, this)
+        , mutex_()
+        , notEmpty_()
+        , finish_()
+        , completed_()
+    {}
 
     ~AsyncDocumentParser() {
         if (!parseThread_.joinable())


### PR DESCRIPTION
Fixed the constructor of `AsyncDocumentParser` to properly initialize all the fields and added pthread link.