### PR TITLE
Fixed build problem with dtoatest.cpp

### DIFF
--- a/test/unittest/dtoatest.cpp
+++ b/test/unittest/dtoatest.cpp
@@ -18,6 +18,7 @@
 #ifdef __GNUC__
 RAPIDJSON_DIAG_PUSH
 RAPIDJSON_DIAG_OFF(type-limits)
+RAPIDJSON_DIAG_OFF(strict-overflow)
 #endif
 
 using namespace rapidjson::internal;


### PR DESCRIPTION
When I build Rapidjson with g++5.2.1,I get such error.

> In member function ‘virtual void dtoa_maxDecimalPlaces_Test::TestBody()’:
cc1plus: error: assuming signed overflow does not occur when assuming that (X - c) > X is always false [-Werror=strict-overflow]

Now I fixed it.