### PR TITLE
do potentially precision-losing conversions explicitly

### DIFF
--- a/include/rapidjson/pointer.h
+++ b/include/rapidjson/pointer.h
@@ -987,11 +987,11 @@ private:
             src_++;
             Ch c = 0;
             for (int j = 0; j < 2; j++) {
-                c <<= 4;
+                c = static_cast<Ch>(c << 4);
                 Ch h = *src_;
-                if      (h >= '0' && h <= '9') c += h - '0';
-                else if (h >= 'A' && h <= 'F') c += h - 'A' + 10;
-                else if (h >= 'a' && h <= 'f') c += h - 'a' + 10;
+                if      (h >= '0' && h <= '9') c = static_cast<Ch>(c + h - '0');
+                else if (h >= 'A' && h <= 'F') c = static_cast<Ch>(c + h - 'A' + 10);
+                else if (h >= 'a' && h <= 'f') c = static_cast<Ch>(c + h - 'a' + 10);
                 else {
                     valid_ = false;
                     return 0;

--- a/test/unittest/itoatest.cpp
+++ b/test/unittest/itoatest.cpp
@@ -93,7 +93,7 @@ static void u32toa_naive(uint32_t value, char* buffer) {
     char temp[10];
     char *p = temp;
     do {
-        *p++ = char(value % 10) + '0';
+        *p++ = static_cast<char>(char(value % 10) + '0');
         value /= 10;
     } while (value > 0);
 
@@ -117,7 +117,7 @@ static void u64toa_naive(uint64_t value, char* buffer) {
     char temp[20];
     char *p = temp;
     do {
-        *p++ = char(value % 10) + '0';
+        *p++ = static_cast<char>(char(value % 10) + '0');
         value /= 10;
     } while (value > 0);
 

--- a/test/unittest/strtodtest.cpp
+++ b/test/unittest/strtodtest.cpp
@@ -42,7 +42,7 @@ TEST(Strtod, CheckApproximationCase) {
     u.u = 0x465a72e467d88 | ((static_cast<uint64_t>(-149 + kExponentBias)) << kSignificandSize);
     const double b = u.d;
     const uint64_t bInt = (u.u & kSignificandMask) | kHiddenBit;
-    const int bExp = ((u.u & kExponentMask) >> kSignificandSize) - kExponentBias - kSignificandSize;
+    const int bExp = static_cast<int>(((u.u & kExponentMask) >> kSignificandSize) - kExponentBias - kSignificandSize);
     EXPECT_DOUBLE_EQ(1.7864e-45, b);
     EXPECT_EQ(RAPIDJSON_UINT64_C2(0x001465a7, 0x2e467d88), bInt);
     EXPECT_EQ(-201, bExp);


### PR DESCRIPTION
Some type conversions which may lead to precision loss especially on 64-bit platforms are done explicitly. As a result, including rapidjson as a thirdparty into another project which uses -Wconversion flag (for g++ and clang) doesn't break compilation of that project.