### PR TITLE
example checks for integer overflow via RAPIDJSON_ALIGN rounding

### DIFF
--- a/include/rapidjson/allocators.h
+++ b/include/rapidjson/allocators.h
@@ -177,7 +177,14 @@ public:
         if (!size)
             return NULL;
 
+        size_t save_sz = size;
+
         size = RAPIDJSON_ALIGN(size);
+
+        if(save_sz > size || size == 0) {
+            return NULL;
+        }
+
         if (chunkHead_ == 0 || chunkHead_->size + size > chunkHead_->capacity)
             AddChunk(chunk_capacity_ > size ? chunk_capacity_ : size);
 
@@ -194,8 +201,14 @@ public:
         if (newSize == 0)
             return NULL;
 
+        size_t save_sz = newSize;
+
         originalSize = RAPIDJSON_ALIGN(originalSize);
         newSize = RAPIDJSON_ALIGN(newSize);
+
+        if(save_sz > newSize || newSize == 0) {
+            return originalPtr;
+        }
 
         // Do not shrink if new size is smaller than original
         if (originalSize >= newSize)


### PR DESCRIPTION
MemoryPoolAllocator::Malloc and MemoryPoolAllocator::Realloc contain potential integer overflows via the rounding macro RAPIDJSON_ALIGN. This example patch checks for that. Its been tested with RapidJson unit tests and all passed. This is just one example of how to do it, YMMV.