### PR TITLE
npm compliant package.json

### DIFF
--- a/include_dirs.js
+++ b/include_dirs.js
@@ -1,0 +1,2 @@
+console.log(require('path').relative('.', __dirname));
+

--- a/include_dirs.js
+++ b/include_dirs.js
@@ -1,2 +1,2 @@
-console.log(require('path').relative('.', __dirname));
-
+var path = require('path');
+console.log(path.join(path.relative('.', __dirname), 'include'));

--- a/package.json
+++ b/package.json
@@ -13,13 +13,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/milkandsour/rapidjson.git"
+    "url": "git+https://github.com/miloyip/rapidjson.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/milkandsour/rapidjson/issues"
+    "url": "https://github.com/miloyip/rapidjson/issues"
   },
-  "homepage": "https://github.com/milkandsour/rapidjson#readme",
+  "homepage": "https://github.com/miloyip/rapidjson#readme",
   "main": "include_dirs.js"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rapidjson",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "![](doc/logo/rapidjson.png)",
   "main": "index.js",
   "directories": {
@@ -20,5 +20,6 @@
   "bugs": {
     "url": "https://github.com/milkandsour/rapidjson/issues"
   },
-  "homepage": "https://github.com/milkandsour/rapidjson#readme"
+  "homepage": "https://github.com/milkandsour/rapidjson#readme",
+  "main": "include_dirs.js"
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "rapidjson",
+  "version": "1.0.2",
+  "description": "![](doc/logo/rapidjson.png)",
+  "main": "index.js",
+  "directories": {
+    "doc": "doc",
+    "example": "example",
+    "test": "test"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/milkandsour/rapidjson.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/milkandsour/rapidjson/issues"
+  },
+  "homepage": "https://github.com/milkandsour/rapidjson#readme"
+}


### PR DESCRIPTION
In order to be able to install rapidjson via npm, I added a package.json and an include_dirs.js as a main.

I use rapidjson  for my own project and I find very useful to install it from npm, also you will have more visibility if you actually publish the package on the npm repo.
