### PR TITLE
Allow options for writing and parsing NaN/Infinity

### DIFF
--- a/doc/dom.md
+++ b/doc/dom.md
@@ -118,6 +118,7 @@ Parse flags                   | Meaning
 `kParseCommentsFlag`          | Allow one-line `// ...` and multi-line `/* ... */` comments (relaxed JSON syntax).
 `kParseNumbersAsStringsFlag`  | Parse numerical type values as strings.
 `kParseTrailingCommasFlag`    | Allow trailing commas at the end of objects and arrays (relaxed JSON syntax).
+`kParseNanAndInfFlag`         | Allow parsing `NaN`, `Inf`, `Infinity`, `-Inf` and `-Infinity` as `double` values (relaxed JSON syntax).
 
 By using a non-type template parameter, instead of a function parameter, C++ compiler can generate code which is optimized for specified combinations, improving speed, and reducing code size (if only using a single specialization). The downside is the flags needed to be determined in compile-time.
 

--- a/test/unittest/readertest.cpp
+++ b/test/unittest/readertest.cpp
@@ -19,6 +19,8 @@
 #include "rapidjson/internal/itoa.h"
 #include "rapidjson/memorystream.h"
 
+#include <limits>
+
 using namespace rapidjson;
 
 #ifdef __GNUC__
@@ -1772,6 +1774,69 @@ TEST(Reader, TrailingCommaHandlerTermination) {
 
 TEST(Reader, TrailingCommaHandlerTerminationIterative) {
     TestTrailingCommaHandlerTermination<kParseIterativeFlag>();
+}
+
+TEST(Reader, ParseNanAndInfinity) {
+#define TEST_NAN_INF(str, x) \
+    { \
+        { \
+            StringStream s(str); \
+            ParseDoubleHandler h; \
+            Reader reader; \
+            ASSERT_EQ(kParseErrorNone, reader.Parse<kParseNanAndInfFlag>(s, h).Code()); \
+            EXPECT_EQ(1u, h.step_); \
+            internal::Double e(x), a(h.actual_); \
+            EXPECT_EQ(e.IsNan(), a.IsNan()); \
+            EXPECT_EQ(e.IsInf(), a.IsInf()); \
+            if (!e.IsNan()) \
+                EXPECT_EQ(e.Sign(), a.Sign()); \
+        } \
+        { \
+            const char* json = "{ \"naninfdouble\": " str " } "; \
+            StringStream s(json); \
+            NumbersAsStringsHandler h(str); \
+            Reader reader; \
+            EXPECT_TRUE(reader.Parse<kParseNumbersAsStringsFlag|kParseNanAndInfFlag>(s, h)); \
+        } \
+        { \
+            char* json = StrDup("{ \"naninfdouble\": " str " } "); \
+            InsituStringStream s(json); \
+            NumbersAsStringsHandler h(str); \
+            Reader reader; \
+            EXPECT_TRUE(reader.Parse<kParseInsituFlag|kParseNumbersAsStringsFlag|kParseNanAndInfFlag>(s, h)); \
+            free(json); \
+        } \
+    }
+#define TEST_NAN_INF_ERROR(errorCode, str, errorOffset) \
+    { \
+        int streamPos = errorOffset; \
+        char buffer[1001]; \
+        strncpy(buffer, str, 1000); \
+        InsituStringStream s(buffer); \
+        BaseReaderHandler<> h; \
+        Reader reader; \
+        EXPECT_FALSE(reader.Parse<kParseNanAndInfFlag>(s, h)); \
+        EXPECT_EQ(errorCode, reader.GetParseErrorCode());\
+        EXPECT_EQ(errorOffset, reader.GetErrorOffset());\
+        EXPECT_EQ(streamPos, s.Tell());\
+    }
+
+    double nan = std::numeric_limits<double>::quiet_NaN();
+    double inf = std::numeric_limits<double>::infinity();
+
+    TEST_NAN_INF("NaN", nan);
+    TEST_NAN_INF("-NaN", nan);
+    TEST_NAN_INF("Inf", inf);
+    TEST_NAN_INF("Infinity", inf);
+    TEST_NAN_INF("-Inf", -inf);
+    TEST_NAN_INF("-Infinity", -inf);
+    TEST_NAN_INF_ERROR(kParseErrorValueInvalid, "nan", 1);
+    TEST_NAN_INF_ERROR(kParseErrorValueInvalid, "-nan", 1);
+    TEST_NAN_INF_ERROR(kParseErrorValueInvalid, "NAN", 1);
+    TEST_NAN_INF_ERROR(kParseErrorValueInvalid, "-Infinty", 6);
+
+#undef TEST_NAN_INF_ERROR
+#undef TEST_NAN_INF
 }
 
 #ifdef __GNUC__

--- a/test/unittest/writertest.cpp
+++ b/test/unittest/writertest.cpp
@@ -446,9 +446,15 @@ TEST(Writer, NaN) {
     double nan = zero / zero;
     EXPECT_TRUE(internal::Double(nan).IsNan());
     StringBuffer buffer;
-    Writer<StringBuffer> writer(buffer);
-    EXPECT_FALSE(writer.Double(nan));
-
+    {
+        Writer<StringBuffer> writer(buffer);
+        EXPECT_FALSE(writer.Double(nan));
+    }
+    {
+        Writer<StringBuffer, UTF8<>, UTF8<>, CrtAllocator, kWriteNanAndInfFlag> writer(buffer);
+        EXPECT_TRUE(writer.Double(nan));
+        EXPECT_STREQ("NaN", buffer.GetString());
+    }
     GenericStringBuffer<UTF16<> > buffer2;
     Writer<GenericStringBuffer<UTF16<> > > writer2(buffer2);
     EXPECT_FALSE(writer2.Double(nan));
@@ -460,12 +466,21 @@ TEST(Writer, Inf) {
     StringBuffer buffer;
     {
         Writer<StringBuffer> writer(buffer);
-        EXPECT_FALSE(writer.Double(inf));        
+        EXPECT_FALSE(writer.Double(inf));
     }
     {
         Writer<StringBuffer> writer(buffer);
         EXPECT_FALSE(writer.Double(-inf));
     }
+    {
+        Writer<StringBuffer, UTF8<>, UTF8<>, CrtAllocator, kWriteNanAndInfFlag> writer(buffer);
+        EXPECT_TRUE(writer.Double(inf));
+    }
+    {
+        Writer<StringBuffer, UTF8<>, UTF8<>, CrtAllocator, kWriteNanAndInfFlag> writer(buffer);
+        EXPECT_TRUE(writer.Double(-inf));
+    }
+    EXPECT_STREQ("Infinity-Infinity", buffer.GetString());
 }
 
 TEST(Writer, RawValue) {


### PR DESCRIPTION
This adds `kWriteNanAndInfFlag` to `Writer` to allow writing of `nan`,
`inf` and `-inf` doubles as "NaN", "Infinity" and "-Infinity",
respectively, and `kParseNanAndInfFlag` to `Reader` to allow parsing
of "NaN", "Inf", "Infinity", "-Inf" and "-Infinity". This is part
of issue #36, adding optional support for relaxed JSON syntax.