### PR TITLE
Update reference to gtest thirdparty module.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "thirdparty/gtest"]
 	path = thirdparty/gtest
-	url = https://chromium.googlesource.com/external/googletest.git
+	url = https://github.com/google/googletest.git


### PR DESCRIPTION
The last time it failed because of [google had rebased it](http://stackoverflow.com/a/9052142/4345903).
Now I updated the reference to gtest now， I can build it successfully manually.