### PR TITLE
document typo fix and .gitignore update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,6 @@ Testing
 /googletest
 install_manifest.txt
 Doxyfile
+Doxyfile.zh-cn
 DartConfiguration.tcl
 *.nupkg

--- a/doc/tutorial.zh-cn.md
+++ b/doc/tutorial.zh-cn.md
@@ -379,7 +379,7 @@ const char * cstr = getenv("USER");
 size_t cstr_len = ...;                 // 如果有长度
 Value s;
 // s.SetString(cstr);                  // 这不能通过编译
-s.SetString(StringRef(cstr));          // 可以，假设它的生命周期案全，并且是以空字符结尾的
+s.SetString(StringRef(cstr));          // 可以，假设它的生命周期安全，并且是以空字符结尾的
 s = StringRef(cstr);                   // 上行的缩写
 s.SetString(StringRef(cstr, cstr_len));// 更快，可处理空字符
 s = StringRef(cstr, cstr_len);         // 上行的缩写


### PR DESCRIPTION
Fix a typo in doc/tutorial.zh-cn.md, and add "Doxyfile.zh-cn" in .gitignore file.