### PR TITLE
Fix warnings on GCC 6 and later (closes #666)

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -25,23 +25,24 @@
 #include <new>      // placement new
 #include <limits>
 
-#ifdef _MSC_VER
 RAPIDJSON_DIAG_PUSH
+#ifdef _MSC_VER
 RAPIDJSON_DIAG_OFF(4127) // conditional expression is constant
 RAPIDJSON_DIAG_OFF(4244) // conversion from kXxxFlags to 'uint16_t', possible loss of data
 #endif
 
 #ifdef __clang__
-RAPIDJSON_DIAG_PUSH
 RAPIDJSON_DIAG_OFF(padded)
 RAPIDJSON_DIAG_OFF(switch-enum)
 RAPIDJSON_DIAG_OFF(c++98-compat)
 #endif
 
 #ifdef __GNUC__
-RAPIDJSON_DIAG_PUSH
 RAPIDJSON_DIAG_OFF(effc++)
+#if __GNUC__ >= 6
+RAPIDJSON_DIAG_OFF(terminate) // ignore throwing RAPIDJSON_ASSERT in RAPIDJSON_NOEXCEPT functions
 #endif
+#endif // __GNUC__
 
 #ifndef RAPIDJSON_NOMEMBERITERATORCLASS
 #include <iterator> // std::iterator, std::random_access_iterator_tag
@@ -2569,17 +2570,6 @@ private:
 };
 
 RAPIDJSON_NAMESPACE_END
-
-#ifdef _MSC_VER
 RAPIDJSON_DIAG_POP
-#endif
-
-#ifdef __clang__
-RAPIDJSON_DIAG_POP
-#endif
-
-#ifdef __GNUC__
-RAPIDJSON_DIAG_POP
-#endif
 
 #endif // RAPIDJSON_DOCUMENT_H_

--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -19,13 +19,6 @@
 #include "pointer.h"
 #include <cmath> // abs, floor
 
-#ifdef __clang__
-RAPIDJSON_DIAG_PUSH
-RAPIDJSON_DIAG_OFF(weak-vtables)
-RAPIDJSON_DIAG_OFF(exit-time-destructors)
-RAPIDJSON_DIAG_OFF(c++98-compat-pedantic)
-#endif
-
 #if !defined(RAPIDJSON_SCHEMA_USE_INTERNALREGEX)
 #define RAPIDJSON_SCHEMA_USE_INTERNALREGEX 1
 #else
@@ -58,18 +51,20 @@ RAPIDJSON_DIAG_OFF(c++98-compat-pedantic)
 #include "stringbuffer.h"
 #endif
 
-#if defined(__GNUC__)
 RAPIDJSON_DIAG_PUSH
+
+#if defined(__GNUC__)
 RAPIDJSON_DIAG_OFF(effc++)
 #endif
 
 #ifdef __clang__
-RAPIDJSON_DIAG_PUSH
+RAPIDJSON_DIAG_OFF(weak-vtables)
+RAPIDJSON_DIAG_OFF(exit-time-destructors)
+RAPIDJSON_DIAG_OFF(c++98-compat-pedantic)
 RAPIDJSON_DIAG_OFF(variadic-macros)
 #endif
 
 #ifdef _MSC_VER
-RAPIDJSON_DIAG_PUSH
 RAPIDJSON_DIAG_OFF(4512) // assignment operator could not be generated
 #endif
 
@@ -1343,7 +1338,7 @@ public:
         \param remoteProvider An optional remote schema document provider for resolving remote reference. Can be null.
         \param allocator An optional allocator instance for allocating memory. Can be null.
     */
-    GenericSchemaDocument(const ValueType& document, IRemoteSchemaDocumentProviderType* remoteProvider = 0, Allocator* allocator = 0) RAPIDJSON_NOEXCEPT : 
+    GenericSchemaDocument(const ValueType& document, IRemoteSchemaDocumentProviderType* remoteProvider = 0, Allocator* allocator = 0) :
         remoteProvider_(remoteProvider),
         allocator_(allocator),
         ownAllocator_(),
@@ -2006,17 +2001,6 @@ private:
 };
 
 RAPIDJSON_NAMESPACE_END
-
-#if defined(__GNUC__)
 RAPIDJSON_DIAG_POP
-#endif
-
-#ifdef __clang__
-RAPIDJSON_DIAG_POP
-#endif
-
-#ifdef _MSC_VER
-RAPIDJSON_DIAG_POP
-#endif
 
 #endif // RAPIDJSON_SCHEMA_H_

--- a/test/unittest/encodingstest.cpp
+++ b/test/unittest/encodingstest.cpp
@@ -302,8 +302,9 @@ TEST(EncodingsTest, UTF8) {
                         decodedCount++;
                     }
 
-                if (*encodedStr)                // This decoder cannot handle U+0000
+                if (*encodedStr) {                  // This decoder cannot handle U+0000
                     EXPECT_EQ(1u, decodedCount);    // Should only contain one code point
+                }
 
                 EXPECT_EQ(UTF8_ACCEPT, state);
                 if (UTF8_ACCEPT != state)

--- a/test/unittest/istreamwrappertest.cpp
+++ b/test/unittest/istreamwrappertest.cpp
@@ -50,8 +50,9 @@ static void TestStringStream() {
         StringStreamType iss(s);
         BasicIStreamWrapper<StringStreamType> is(iss);
         EXPECT_EQ(0, is.Tell());
-        if (sizeof(Ch) == 1)
+        if (sizeof(Ch) == 1) {
             EXPECT_EQ(0, is.Peek4()); // less than 4 bytes
+        }
         for (int i = 0; i < 3; i++) {
             EXPECT_EQ(static_cast<size_t>(i), is.Tell());
             EXPECT_EQ('A' + i, is.Peek());

--- a/test/unittest/readertest.cpp
+++ b/test/unittest/readertest.cpp
@@ -23,15 +23,17 @@
 
 using namespace rapidjson;
 
-#ifdef __GNUC__
 RAPIDJSON_DIAG_PUSH
+#ifdef __GNUC__
 RAPIDJSON_DIAG_OFF(effc++)
 RAPIDJSON_DIAG_OFF(float-equal)
 RAPIDJSON_DIAG_OFF(missing-noreturn)
+#if __GNUC__ >= 6
+RAPIDJSON_DIAG_OFF(dangling-else)
 #endif
+#endif // __GNUC__
 
 #ifdef __clang__
-RAPIDJSON_DIAG_PUSH
 RAPIDJSON_DIAG_OFF(variadic-macros)
 RAPIDJSON_DIAG_OFF(c++98-compat-pedantic)
 #endif
@@ -1839,10 +1841,4 @@ TEST(Reader, ParseNanAndInfinity) {
 #undef TEST_NAN_INF
 }
 
-#ifdef __GNUC__
 RAPIDJSON_DIAG_POP
-#endif
-
-#ifdef __clang__
-RAPIDJSON_DIAG_POP
-#endif


### PR DESCRIPTION
This pull-request fixes the warnings on GCC 6 and later as reported in #666 and validated locally.

* `document.h` 
  * suppress `-Wterminate` on GCC 6.x and later
  * simplify warning handling
* `schema.h`
  * drop `RAPIDJSON_NOEXCEPT` from `GenericSchemaDocument` constructor     (calls `RAPIDJSON_NEW` anyway)
  * simplify warning handling (avoids `RAPIDJSON_POP` mismatch on Clang)
* `encodingtest.cpp`, `istreamwrappertest.cpp`
  * work around `-Wdangling-else`
* `readertest.cpp`
  * suppress `-Wdangling-else`