### PR TITLE
readertest: Suppress "dangling-else" warning on GCC 7 and later

### DIFF
--- a/test/unittest/readertest.cpp
+++ b/test/unittest/readertest.cpp
@@ -28,7 +28,7 @@ RAPIDJSON_DIAG_PUSH
 RAPIDJSON_DIAG_OFF(effc++)
 RAPIDJSON_DIAG_OFF(float-equal)
 RAPIDJSON_DIAG_OFF(missing-noreturn)
-#if __GNUC__ >= 6
+#if __GNUC__ >= 7
 RAPIDJSON_DIAG_OFF(dangling-else)
 #endif
 #endif // __GNUC__


### PR DESCRIPTION
GCC 6.x doesn't yet support this warning flag, as reported by @ragnar-ouchterlony in #666.

This has now been verified on Linux, x86_64, with GCC versions
```
g++-5 (Debian 5.4.0-4) 5.4.0 20160609
g++-6 (Debian 6.1.1-7) 6.1.1 20160620
g++-snapshot (Debian 20160612-1) 7.0.0 20160612 (experimental) [trunk revision 237336]
```