### PR TITLE
Fix buffer overrun using PutN (closes #672)

### DIFF
--- a/include/rapidjson/stream.h
+++ b/include/rapidjson/stream.h
@@ -95,7 +95,7 @@ inline void PutUnsafe(Stream& stream, typename Stream::Ch c) {
 //! Put N copies of a character to a stream.
 template<typename Stream, typename Ch>
 inline void PutN(Stream& stream, Ch c, size_t n) {
-    PutReserve<Stream>(stream, n);
+    PutReserve(stream, n);
     for (size_t i = 0; i < n; i++)
         PutUnsafe(stream, c);
 }

--- a/test/unittest/stringbuffertest.cpp
+++ b/test/unittest/stringbuffertest.cpp
@@ -37,6 +37,13 @@ TEST(StringBuffer, Put) {
     EXPECT_STREQ("A", buffer.GetString());
 }
 
+TEST(StringBuffer, PutN_Issue672) {
+    GenericStringBuffer<UTF8<>, MemoryPoolAllocator<> > buffer;
+    EXPECT_EQ(0, buffer.GetSize());
+    rapidjson::PutN(buffer, ' ', 1);
+    EXPECT_EQ(1, buffer.GetSize());
+}
+
 TEST(StringBuffer, Clear) {
     StringBuffer buffer;
     buffer.Put('A');


### PR DESCRIPTION
Fix inconsistent calling of template functions in PutN in stream.h. When
used with a GenericStringBuffer<<UTF8>, MemoryPoolAllocator>, PutN would call
PutReserve from stream.h, and PutUnsafe from stringbuffer.h. This
resulted in bytes being added to the buffer without allocating space.

This was not an issue when used with the default memory allocator,
because in this case the specialized PutN is used from stringbuffer.h.