### PR TITLE
Make GenericSchemaDocument constructor explicit

### DIFF
--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -1338,7 +1338,7 @@ public:
         \param remoteProvider An optional remote schema document provider for resolving remote reference. Can be null.
         \param allocator An optional allocator instance for allocating memory. Can be null.
     */
-    GenericSchemaDocument(const ValueType& document, IRemoteSchemaDocumentProviderType* remoteProvider = 0, Allocator* allocator = 0) :
+    explicit GenericSchemaDocument(const ValueType& document, IRemoteSchemaDocumentProviderType* remoteProvider = 0, Allocator* allocator = 0) :
         remoteProvider_(remoteProvider),
         allocator_(allocator),
         ownAllocator_(),


### PR DESCRIPTION
Prior to this change, a user could incorrectly pass a Document object to
SchemaValidator. This would implicitly construct a SchemaDocument, which
would then be destructed before the validator was used. This caused
unpredictable results including memory corruption and program crashes.

Consider the following snippet, which compiles cleanly but does not behave as expected, because the wrong variable was passed to the SchemaValidator constructor:

```
    Document sd;
    sd.Parse("{}");
    SchemaDocument schema(sd);
    SchemaValidator validator(sd);

    Document testDoc;
    testDoc.Parse("10");
    testDoc.Accept(validator);
```
