### PR TITLE
add significant figures to double

### DIFF
--- a/include/rapidjson/internal/dtoa.h
+++ b/include/rapidjson/internal/dtoa.h
@@ -148,6 +148,25 @@ inline char* WriteExponent(int K, char* buffer) {
 }
 
 inline char* Prettify(char* buffer, int length, int k, int maxDecimalPlaces) {
+
+	const int sig = 7;
+
+	if( length > sig ){
+
+		int delta = length - sig;
+		buffer[sig] = 0;
+		length = sig;
+
+		for( int i = sig-1; i > 0 && buffer[i] == '0'; i-- ){
+			buffer[i] = 0;
+			length--;
+			delta++;
+		}
+
+		k += delta;
+
+	}
+
     const int kk = length + k;  // 10^(kk-1) <= v < 10^kk
 
     if (0 <= k && kk <= 21) {


### PR DESCRIPTION
You support max decimals in serializing doubles, but what I need is significant figures.  I'm getting noise I don't want from (e.g.) 3.0/10 => "0.30000000000000007".  

Note that this isn't a full implementation, because (for one thing) it does no rounding.  It's just an implementation idea.