### PR TITLE
Add std::string overload to PrettyWriter::Key() when RAPIDJSON_HAS_STDSTRING is #defined

### DIFF
--- a/include/rapidjson/prettywriter.h
+++ b/include/rapidjson/prettywriter.h
@@ -115,6 +115,12 @@ public:
     }
 
     bool Key(const Ch* str, SizeType length, bool copy = false) { return String(str, length, copy); }
+
+#if RAPIDJSON_HAS_STDSTRING
+    bool Key(const std::basic_string<Ch>& str) {
+        return Key(str.data(), SizeType(str.size()));
+    }
+#endif
 	
     bool EndObject(SizeType memberCount = 0) {
         (void)memberCount;


### PR DESCRIPTION
Only String() has the std::string overload currently.