### PR TITLE
Fix some usage of rvalue references

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -1262,17 +1262,17 @@ public:
 
 #if RAPIDJSON_HAS_CXX11_RVALUE_REFS
     GenericValue& AddMember(GenericValue&& name, GenericValue&& value, Allocator& allocator) {
-        return AddMember(name, value, allocator);
+        return AddMember(std::move(name), std::move(value), allocator);
     }
     GenericValue& AddMember(GenericValue&& name, GenericValue& value, Allocator& allocator) {
-        return AddMember(name, value, allocator);
+        return AddMember(std::move(name), value, allocator);
     }
     GenericValue& AddMember(GenericValue& name, GenericValue&& value, Allocator& allocator) {
-        return AddMember(name, value, allocator);
+        return AddMember(name, std::move(value), allocator);
     }
     GenericValue& AddMember(StringRefType name, GenericValue&& value, Allocator& allocator) {
         GenericValue n(name);
-        return AddMember(n, value, allocator);
+        return AddMember(n, std::move(value), allocator);
     }
 #endif // RAPIDJSON_HAS_CXX11_RVALUE_REFS
 
@@ -1548,7 +1548,7 @@ public:
 
 #if RAPIDJSON_HAS_CXX11_RVALUE_REFS
     GenericValue& PushBack(GenericValue&& value, Allocator& allocator) {
-        return PushBack(value, allocator);
+        return PushBack(std::move(value), allocator);
     }
 #endif // RAPIDJSON_HAS_CXX11_RVALUE_REFS
 


### PR DESCRIPTION
`std::move` is missing in a few places.
