### PR TITLE
Fix for winmindef.h defining min/max macros

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -29,6 +29,14 @@ RAPIDJSON_DIAG_PUSH
 #ifdef _MSC_VER
 RAPIDJSON_DIAG_OFF(4127) // conditional expression is constant
 RAPIDJSON_DIAG_OFF(4244) // conversion from kXxxFlags to 'uint16_t', possible loss of data
+#ifdef _MINWINDEF_       // see: http://stackoverflow.com/questions/22744262/cant-call-stdmax-because-minwindef-h-defines-max
+#ifndef NOMINMAX
+#pragma push_macro("min")
+#pragma push_macro("max")
+#undef min
+#undef max
+#endif
+#endif
 #endif
 
 #ifdef __clang__
@@ -2570,6 +2578,12 @@ private:
 };
 
 RAPIDJSON_NAMESPACE_END
+#ifdef _MINWINDEF_       // see: http://stackoverflow.com/questions/22744262/cant-call-stdmax-because-minwindef-h-defines-max
+#ifndef NOMINMAX
+#pragma pop_macro("min")
+#pragma pop_macro("max")
+#endif
+#endif
 RAPIDJSON_DIAG_POP
 
 #endif // RAPIDJSON_DOCUMENT_H_


### PR DESCRIPTION
winmindef.h defines macros for `min` and `max` which cause several lines in documents.h to be expanded incorrectly whilst only presenting warnings that min and max lacked sufficient arguments.

See: http://stackoverflow.com/questions/22744262/cant-call-stdmax-because-minwindef-h-defines-max for more information.