### PR TITLE
Fix compilation with older GCC versions

### DIFF
--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -575,7 +575,7 @@ private:
                     }
                 }
                 else if (RAPIDJSON_LIKELY(Consume(is, '/')))
-                    while (is.Peek() != '\0' && is.Take() != '\n');
+                    while (is.Peek() != '\0' && is.Take() != '\n') {}
                 else
                     RAPIDJSON_PARSE_ERROR(kParseErrorUnspecificSyntaxError, is.Tell());
 


### PR DESCRIPTION
Older GCC versions fail compiling RapidJSON due to a warning

include/rapidjson/reader.h:578: error: suggest a space before ';' or explicit braces around empty body in 'while' statement
: warnings being treated as errors