### PR TITLE
added assertion to help suppress clang warnings

### DIFF
--- a/include/rapidjson/internal/stack.h
+++ b/include/rapidjson/internal/stack.h
@@ -113,7 +113,6 @@ public:
     // Expansion is run very infrequently, so it is moved to another (probably non-inline) function.
     template<typename T>
     RAPIDJSON_FORCEINLINE void Reserve(size_t count = 1) {
-        RAPIDJSON_ASSERT(stackTop_);
          // Expand the stack if needed
         if (RAPIDJSON_UNLIKELY(stackTop_ + sizeof(T) * count > stackEnd_))
             Expand<T>(count);

--- a/include/rapidjson/internal/stack.h
+++ b/include/rapidjson/internal/stack.h
@@ -113,6 +113,7 @@ public:
     // Expansion is run very infrequently, so it is moved to another (probably non-inline) function.
     template<typename T>
     RAPIDJSON_FORCEINLINE void Reserve(size_t count = 1) {
+        RAPIDJSON_ASSERT(stackTop_);
          // Expand the stack if needed
         if (RAPIDJSON_UNLIKELY(stackTop_ + sizeof(T) * count > stackEnd_))
             Expand<T>(count);
@@ -126,6 +127,7 @@ public:
 
     template<typename T>
     RAPIDJSON_FORCEINLINE T* PushUnsafe(size_t count = 1) {
+        RAPIDJSON_ASSERT(stackTop_);
         RAPIDJSON_ASSERT(stackTop_ + sizeof(T) * count <= stackEnd_);
         T* ret = reinterpret_cast<T*>(stackTop_);
         stackTop_ += sizeof(T) * count;

--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -948,11 +948,13 @@ private:
     #else
                 length = static_cast<SizeType>(__builtin_ffs(r) - 1);
     #endif
-                char* q = reinterpret_cast<char*>(os.Push(length));
-                for (size_t i = 0; i < length; i++)
-                    q[i] = p[i];
+                if (length != 0) {
+                    char* q = reinterpret_cast<char*>(os.Push(length));
+                    for (size_t i = 0; i < length; i++)
+                        q[i] = p[i];
 
-                p += length;
+                    p += length;
+                }
                 break;
             }
             _mm_storeu_si128(reinterpret_cast<__m128i *>(os.Push(16)), s);


### PR DESCRIPTION
Similar to https://github.com/miloyip/rapidjson/pull/727

But the clang warning I got traced back to the pointer returned by `PushUnsafe`.

I assume this case never happens, so an assert should be sufficient. At least clang is happy with an assertion.
