### PR TITLE
Add optional length parameter to GenericStringStream constructor

### DIFF
--- a/include/rapidjson/stream.h
+++ b/include/rapidjson/stream.h
@@ -110,10 +110,11 @@ template <typename Encoding>
 struct GenericStringStream {
     typedef typename Encoding::Ch Ch;
 
-    GenericStringStream(const Ch *src) : src_(src), head_(src) {}
+    GenericStringStream(const Ch *src) : src_(src), head_(src), end_(0) {}
+    GenericStringStream(const Ch *src, size_t len) : src_(src), head_(src), end_(src + len) {}
 
-    Ch Peek() const { return *src_; }
-    Ch Take() { return *src_++; }
+    Ch Peek() const { return (end_ && src_ >= end_) ? 0 : *src_; }
+    Ch Take() { return (end_ && src_ >= end_) ? 0 : *src_++; }
     size_t Tell() const { return static_cast<size_t>(src_ - head_); }
 
     Ch* PutBegin() { RAPIDJSON_ASSERT(false); return 0; }
@@ -123,6 +124,7 @@ struct GenericStringStream {
 
     const Ch* src_;     //!< Current read position.
     const Ch* head_;    //!< Original head of the string.
+    const Ch* end_;     //!< End of string
 };
 
 template <typename Encoding>


### PR DESCRIPTION
In order to be able to reference sub-strings (segments that are not zero-terminated) in `GenericStringStream,` a length parameter is necessary.

If the length parameter is not used, the compiler will optimize away the comparisons added in `Peek()` and `Tell()`, so this modification should not have any impact on performance.