### PR TITLE
Improved customization of RAPIDJSON_NEW macro

### DIFF
--- a/include/rapidjson/allocators.h
+++ b/include/rapidjson/allocators.h
@@ -236,7 +236,7 @@ private:
     */
     bool AddChunk(size_t capacity) {
         if (!baseAllocator_)
-            ownBaseAllocator_ = baseAllocator_ = RAPIDJSON_NEW(BaseAllocator);
+            ownBaseAllocator_ = baseAllocator_ = RAPIDJSON_NEW(BaseAllocator)();
         if (ChunkHeader* chunk = reinterpret_cast<ChunkHeader*>(baseAllocator_->Malloc(RAPIDJSON_ALIGN(sizeof(ChunkHeader)) + capacity))) {
             chunk->capacity = capacity;
             chunk->size = 0;

--- a/include/rapidjson/allocators.h
+++ b/include/rapidjson/allocators.h
@@ -236,7 +236,7 @@ private:
     */
     bool AddChunk(size_t capacity) {
         if (!baseAllocator_)
-            ownBaseAllocator_ = baseAllocator_ = RAPIDJSON_NEW(BaseAllocator());
+            ownBaseAllocator_ = baseAllocator_ = RAPIDJSON_NEW(BaseAllocator);
         if (ChunkHeader* chunk = reinterpret_cast<ChunkHeader*>(baseAllocator_->Malloc(RAPIDJSON_ALIGN(sizeof(ChunkHeader)) + capacity))) {
             chunk->capacity = capacity;
             chunk->size = 0;

--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -2088,7 +2088,7 @@ public:
         GenericValue<Encoding, Allocator>(type),  allocator_(allocator), ownAllocator_(0), stack_(stackAllocator, stackCapacity), parseResult_()
     {
         if (!allocator_)
-            ownAllocator_ = allocator_ = RAPIDJSON_NEW(Allocator);
+            ownAllocator_ = allocator_ = RAPIDJSON_NEW(Allocator)();
     }
 
     //! Constructor
@@ -2101,7 +2101,7 @@ public:
         allocator_(allocator), ownAllocator_(0), stack_(stackAllocator, stackCapacity), parseResult_()
     {
         if (!allocator_)
-            ownAllocator_ = allocator_ = RAPIDJSON_NEW(Allocator);
+            ownAllocator_ = allocator_ = RAPIDJSON_NEW(Allocator)();
     }
 
 #if RAPIDJSON_HAS_CXX11_RVALUE_REFS

--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -2088,7 +2088,7 @@ public:
         GenericValue<Encoding, Allocator>(type),  allocator_(allocator), ownAllocator_(0), stack_(stackAllocator, stackCapacity), parseResult_()
     {
         if (!allocator_)
-            ownAllocator_ = allocator_ = RAPIDJSON_NEW(Allocator());
+            ownAllocator_ = allocator_ = RAPIDJSON_NEW(Allocator);
     }
 
     //! Constructor
@@ -2101,7 +2101,7 @@ public:
         allocator_(allocator), ownAllocator_(0), stack_(stackAllocator, stackCapacity), parseResult_()
     {
         if (!allocator_)
-            ownAllocator_ = allocator_ = RAPIDJSON_NEW(Allocator());
+            ownAllocator_ = allocator_ = RAPIDJSON_NEW(Allocator);
     }
 
 #if RAPIDJSON_HAS_CXX11_RVALUE_REFS

--- a/include/rapidjson/internal/regex.h
+++ b/include/rapidjson/internal/regex.h
@@ -606,7 +606,7 @@ public:
     {
         RAPIDJSON_ASSERT(regex_.IsValid());
         if (!allocator_)
-            ownAllocator_ = allocator_ = RAPIDJSON_NEW(Allocator());
+            ownAllocator_ = allocator_ = RAPIDJSON_NEW(Allocator);
         stateSet_ = static_cast<unsigned*>(allocator_->Malloc(GetStateSetSize()));
         state0_.template Reserve<SizeType>(regex_.stateCount_);
         state1_.template Reserve<SizeType>(regex_.stateCount_);

--- a/include/rapidjson/internal/regex.h
+++ b/include/rapidjson/internal/regex.h
@@ -606,7 +606,7 @@ public:
     {
         RAPIDJSON_ASSERT(regex_.IsValid());
         if (!allocator_)
-            ownAllocator_ = allocator_ = RAPIDJSON_NEW(Allocator);
+            ownAllocator_ = allocator_ = RAPIDJSON_NEW(Allocator)();
         stateSet_ = static_cast<unsigned*>(allocator_->Malloc(GetStateSetSize()));
         state0_.template Reserve<SizeType>(regex_.stateCount_);
         state1_.template Reserve<SizeType>(regex_.stateCount_);

--- a/include/rapidjson/internal/stack.h
+++ b/include/rapidjson/internal/stack.h
@@ -183,7 +183,7 @@ private:
         size_t newCapacity;
         if (stack_ == 0) {
             if (!allocator_)
-                ownAllocator_ = allocator_ = RAPIDJSON_NEW(Allocator());
+                ownAllocator_ = allocator_ = RAPIDJSON_NEW(Allocator);
             newCapacity = initialCapacity_;
         } else {
             newCapacity = GetCapacity();

--- a/include/rapidjson/internal/stack.h
+++ b/include/rapidjson/internal/stack.h
@@ -183,7 +183,7 @@ private:
         size_t newCapacity;
         if (stack_ == 0) {
             if (!allocator_)
-                ownAllocator_ = allocator_ = RAPIDJSON_NEW(Allocator);
+                ownAllocator_ = allocator_ = RAPIDJSON_NEW(Allocator)();
             newCapacity = initialCapacity_;
         } else {
             newCapacity = GetCapacity();

--- a/include/rapidjson/pointer.h
+++ b/include/rapidjson/pointer.h
@@ -758,7 +758,7 @@ private:
     */
     Ch* CopyFromRaw(const GenericPointer& rhs, size_t extraToken = 0, size_t extraNameBufferSize = 0) {
         if (!allocator_) // allocator is independently owned.
-            ownAllocator_ = allocator_ = RAPIDJSON_NEW(Allocator);
+            ownAllocator_ = allocator_ = RAPIDJSON_NEW(Allocator)();
 
         size_t nameBufferSize = rhs.tokenCount_; // null terminators for tokens
         for (Token *t = rhs.tokens_; t != rhs.tokens_ + rhs.tokenCount_; ++t)
@@ -806,7 +806,7 @@ private:
 
         // Create own allocator if user did not supply.
         if (!allocator_)
-            ownAllocator_ = allocator_ = RAPIDJSON_NEW(Allocator);
+            ownAllocator_ = allocator_ = RAPIDJSON_NEW(Allocator)();
 
         // Count number of '/' as tokenCount
         tokenCount_ = 0;

--- a/include/rapidjson/pointer.h
+++ b/include/rapidjson/pointer.h
@@ -758,7 +758,7 @@ private:
     */
     Ch* CopyFromRaw(const GenericPointer& rhs, size_t extraToken = 0, size_t extraNameBufferSize = 0) {
         if (!allocator_) // allocator is independently owned.
-            ownAllocator_ = allocator_ = RAPIDJSON_NEW(Allocator());
+            ownAllocator_ = allocator_ = RAPIDJSON_NEW(Allocator);
 
         size_t nameBufferSize = rhs.tokenCount_; // null terminators for tokens
         for (Token *t = rhs.tokens_; t != rhs.tokens_ + rhs.tokenCount_; ++t)
@@ -806,7 +806,7 @@ private:
 
         // Create own allocator if user did not supply.
         if (!allocator_)
-            ownAllocator_ = allocator_ = RAPIDJSON_NEW(Allocator());
+            ownAllocator_ = allocator_ = RAPIDJSON_NEW(Allocator);
 
         // Count number of '/' as tokenCount
         tokenCount_ = 0;

--- a/include/rapidjson/rapidjson.h
+++ b/include/rapidjson/rapidjson.h
@@ -583,7 +583,7 @@ RAPIDJSON_NAMESPACE_END
 
 #ifndef RAPIDJSON_NEW
 ///! customization point for global \c new
-#define RAPIDJSON_NEW(x) new x
+#define RAPIDJSON_NEW(type, ...) new type(__VA_ARGS__)
 #endif
 #ifndef RAPIDJSON_DELETE
 ///! customization point for global \c delete

--- a/include/rapidjson/rapidjson.h
+++ b/include/rapidjson/rapidjson.h
@@ -583,7 +583,7 @@ RAPIDJSON_NAMESPACE_END
 
 #ifndef RAPIDJSON_NEW
 ///! customization point for global \c new
-#define RAPIDJSON_NEW(type, ...) new type(__VA_ARGS__)
+#define RAPIDJSON_NEW(TypeName) new TypeName
 #endif
 #ifndef RAPIDJSON_DELETE
 ///! customization point for global \c delete

--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -1344,7 +1344,7 @@ public:
         schemaRef_(allocator, kInitialSchemaRefSize)
     {
         if (!allocator_)
-            ownAllocator_ = allocator_ = RAPIDJSON_NEW(Allocator());
+            ownAllocator_ = allocator_ = RAPIDJSON_NEW(Allocator);
 
         typeless_ = static_cast<SchemaType*>(allocator_->Malloc(sizeof(SchemaType)));
         new (typeless_) SchemaType(this, PointerType(), ValueType(kObjectType).Move(), ValueType(kObjectType).Move(), 0);
@@ -1823,7 +1823,7 @@ private:
 
     StateAllocator& GetStateAllocator() {
         if (!stateAllocator_)
-            stateAllocator_ = ownStateAllocator_ = RAPIDJSON_NEW(StateAllocator());
+            stateAllocator_ = ownStateAllocator_ = RAPIDJSON_NEW(StateAllocator);
         return *stateAllocator_;
     }
 

--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -1344,7 +1344,7 @@ public:
         schemaRef_(allocator, kInitialSchemaRefSize)
     {
         if (!allocator_)
-            ownAllocator_ = allocator_ = RAPIDJSON_NEW(Allocator);
+            ownAllocator_ = allocator_ = RAPIDJSON_NEW(Allocator)();
 
         typeless_ = static_cast<SchemaType*>(allocator_->Malloc(sizeof(SchemaType)));
         new (typeless_) SchemaType(this, PointerType(), ValueType(kObjectType).Move(), ValueType(kObjectType).Move(), 0);
@@ -1823,7 +1823,7 @@ private:
 
     StateAllocator& GetStateAllocator() {
         if (!stateAllocator_)
-            stateAllocator_ = ownStateAllocator_ = RAPIDJSON_NEW(StateAllocator);
+            stateAllocator_ = ownStateAllocator_ = RAPIDJSON_NEW(StateAllocator)();
         return *stateAllocator_;
     }
 

--- a/test/unittest/fwdtest.cpp
+++ b/test/unittest/fwdtest.cpp
@@ -100,6 +100,9 @@ struct Foo {
 #include "rapidjson/prettywriter.h"
 #include "rapidjson/schema.h"   // -> pointer.h
 
+typedef Transcoder<UTF8<>, UTF8<> > TranscoderUtf8ToUtf8;
+typedef BaseReaderHandler<UTF8<>, void> BaseReaderHandlerUtf8Void;
+
 Foo::Foo() : 
     // encodings.h
     utf8(RAPIDJSON_NEW(UTF8<>)),
@@ -111,40 +114,40 @@ Foo::Foo() :
     utf32le(RAPIDJSON_NEW(UTF32LE<>)),
     ascii(RAPIDJSON_NEW(ASCII<>)),
     autoutf(RAPIDJSON_NEW(AutoUTF<unsigned>)),
-    transcoder(RAPIDJSON_NEW((Transcoder<UTF8<>, UTF8<> >))),
+    transcoder(RAPIDJSON_NEW(TranscoderUtf8ToUtf8)),
 
     // allocators.h
     crtallocator(RAPIDJSON_NEW(CrtAllocator)),
     memorypoolallocator(RAPIDJSON_NEW(MemoryPoolAllocator<>)),
 
     // stream.h
-    stringstream(RAPIDJSON_NEW(StringStream, NULL)),
-    insitustringstream(RAPIDJSON_NEW(InsituStringStream, NULL)),
+    stringstream(RAPIDJSON_NEW(StringStream)(NULL)),
+    insitustringstream(RAPIDJSON_NEW(InsituStringStream)(NULL)),
 
     // stringbuffer.h
     stringbuffer(RAPIDJSON_NEW(StringBuffer)),
 
     // // filereadstream.h
-    // filereadstream(RAPIDJSON_NEW(FileReadStream, stdout, buffer, sizeof(buffer))),
+    // filereadstream(RAPIDJSON_NEW(FileReadStream)(stdout, buffer, sizeof(buffer))),
 
     // // filewritestream.h
-    // filewritestream(RAPIDJSON_NEW(FileWriteStream, stdout, buffer, sizeof(buffer))),
+    // filewritestream(RAPIDJSON_NEW(FileWriteStream)(stdout, buffer, sizeof(buffer))),
 
     // memorybuffer.h
     memorybuffer(RAPIDJSON_NEW(MemoryBuffer)),
 
     // memorystream.h
-    memorystream(RAPIDJSON_NEW(MemoryStream, NULL, 0)),
+    memorystream(RAPIDJSON_NEW(MemoryStream)(NULL, 0)),
 
     // reader.h
-    basereaderhandler(RAPIDJSON_NEW((BaseReaderHandler<UTF8<>, void>))),
+    basereaderhandler(RAPIDJSON_NEW(BaseReaderHandlerUtf8Void)),
     reader(RAPIDJSON_NEW(Reader)),
 
     // writer.h
-    writer(RAPIDJSON_NEW((Writer<StringBuffer>))),
+    writer(RAPIDJSON_NEW(Writer<StringBuffer>)),
 
     // prettywriter.h
-    prettywriter(RAPIDJSON_NEW((PrettyWriter<StringBuffer>))),
+    prettywriter(RAPIDJSON_NEW(PrettyWriter<StringBuffer>)),
 
     // document.h
     value(RAPIDJSON_NEW(Value)),
@@ -154,8 +157,8 @@ Foo::Foo() :
     pointer(RAPIDJSON_NEW(Pointer)),
 
     // schema.h
-    schemadocument(RAPIDJSON_NEW(SchemaDocument, *document)),
-    schemavalidator(RAPIDJSON_NEW(SchemaValidator, *schemadocument))
+    schemadocument(RAPIDJSON_NEW(SchemaDocument)(*document)),
+    schemavalidator(RAPIDJSON_NEW(SchemaValidator)(*schemadocument))
 {
 
 }

--- a/test/unittest/fwdtest.cpp
+++ b/test/unittest/fwdtest.cpp
@@ -118,23 +118,23 @@ Foo::Foo() :
     memorypoolallocator(RAPIDJSON_NEW(MemoryPoolAllocator<>)),
 
     // stream.h
-    stringstream(RAPIDJSON_NEW(StringStream(0))),
-    insitustringstream(RAPIDJSON_NEW(InsituStringStream(0))),
+    stringstream(RAPIDJSON_NEW(StringStream, NULL)),
+    insitustringstream(RAPIDJSON_NEW(InsituStringStream, NULL)),
 
     // stringbuffer.h
     stringbuffer(RAPIDJSON_NEW(StringBuffer)),
 
     // // filereadstream.h
-    // filereadstream(RAPIDJSON_NEW(FileReadStream(stdout, buffer, sizeof(buffer)))),
+    // filereadstream(RAPIDJSON_NEW(FileReadStream, stdout, buffer, sizeof(buffer))),
 
     // // filewritestream.h
-    // filewritestream(RAPIDJSON_NEW(FileWriteStream(stdout, buffer, sizeof(buffer)))),
+    // filewritestream(RAPIDJSON_NEW(FileWriteStream, stdout, buffer, sizeof(buffer))),
 
     // memorybuffer.h
     memorybuffer(RAPIDJSON_NEW(MemoryBuffer)),
 
     // memorystream.h
-    memorystream(RAPIDJSON_NEW(MemoryStream(0, 0))),
+    memorystream(RAPIDJSON_NEW(MemoryStream, NULL, 0)),
 
     // reader.h
     basereaderhandler(RAPIDJSON_NEW((BaseReaderHandler<UTF8<>, void>))),
@@ -154,8 +154,8 @@ Foo::Foo() :
     pointer(RAPIDJSON_NEW(Pointer)),
 
     // schema.h
-    schemadocument(RAPIDJSON_NEW(SchemaDocument(*document))),
-    schemavalidator(RAPIDJSON_NEW(SchemaValidator(*schemadocument)))
+    schemadocument(RAPIDJSON_NEW(SchemaDocument, *document)),
+    schemavalidator(RAPIDJSON_NEW(SchemaValidator, *schemadocument))
 {
 
 }


### PR DESCRIPTION
**Reason for change**
I am currently integrating RapidJSON into a large project with high performance requirements where custom allocation support is a must. Allocation is done via a custom `scalable_alloc()` function, so the syntax differs from the `new` expression (as does most any custom allocation function's syntax).
So, the object initialization should be `new(scalable_alloc(sizeof(Type)) Type(Args...)`. But the macro's argument `x` supplies the expression `Type(Args...)`. Thankfully, all uses of `RAPIDJSON_NEW` in the library have the form `RAPIDJSON_NEW(AllocatorType())`. This allowed me to hack together a custom type trait that extracts the `Type` part of `Type()` expressions with empty parentheses (works because the expression `Type()` is also a function signature):
```
template<typename> struct return_type;
template<typename R> struct return_type<R()> { using type = R; };
template<typename T> using return_type_t = typename return_type<T>::type;
```
Then the macro reads something like: `new(scalable_alloc(sizeof(return_type_t<x>)) x` which works if default initialization is used but breaks in any other case.

**Proposed solution**
Change the `RAPIDJSON_NEW` macro signature to `RAPIDJSON_NEW(type, ...)` and the default implementation to `new type(__VA_ARGS__)` as is done in this pull request.
This will allow custom allocation functions to be used without type trait hacking consistently with any amount of constructor arguments, e.g. `new(scalable_alloc(sizeof(type))) type(__VA_ARGS__)`.

Committed code tested on Windows 7 with Visual Studio 2012 (64 bit).