### PR TITLE
Improved reporting

### DIFF
--- a/test/unittest/jsoncheckertest.cpp
+++ b/test/unittest/jsoncheckertest.cpp
@@ -69,10 +69,10 @@ TEST(JsonChecker, Reader) {
 
         GenericDocument<UTF8<>, CrtAllocator> document; // Use Crt allocator to check exception-safety (no memory leak)
         document.Parse(json);
-        EXPECT_TRUE(document.HasParseError());
+        EXPECT_TRUE(document.HasParseError()) << filename;
 
         document.Parse<kParseIterativeFlag>(json);
-        EXPECT_TRUE(document.HasParseError());
+        EXPECT_TRUE(document.HasParseError()) << filename;
 
         free(json);
     }
@@ -89,10 +89,10 @@ TEST(JsonChecker, Reader) {
 
         GenericDocument<UTF8<>, CrtAllocator> document; // Use Crt allocator to check exception-safety (no memory leak)
         document.Parse(json);
-        EXPECT_FALSE(document.HasParseError());
+        EXPECT_FALSE(document.HasParseError()) << filename;
 
         document.Parse<kParseIterativeFlag>(json);
-        EXPECT_FALSE(document.HasParseError());
+        EXPECT_FALSE(document.HasParseError()) << filename;
 
         free(json);
     }


### PR DESCRIPTION
Add “filename” to the error message when JsonChecker reports an error.