### PR TITLE
adding user defined SizeType to the writer

### DIFF
--- a/include/rapidjson/prettywriter.h
+++ b/include/rapidjson/prettywriter.h
@@ -49,6 +49,7 @@ class PrettyWriter : public Writer<OutputStream, SourceEncoding, TargetEncoding,
 public:
     typedef Writer<OutputStream, SourceEncoding, TargetEncoding, StackAllocator> Base;
     typedef typename Base::Ch Ch;
+    typedef typename Base::size_type size_type;
 
     //! Constructor
     /*! \param os Output stream.

--- a/include/rapidjson/writer.h
+++ b/include/rapidjson/writer.h
@@ -89,6 +89,7 @@ template<typename OutputStream, typename SourceEncoding = UTF8<>, typename Targe
 class Writer {
 public:
     typedef typename SourceEncoding::Ch Ch;
+    typedef SizeType size_type;
 
     static const int kDefaultMaxDecimalPlaces = 324;
 


### PR DESCRIPTION
Added typedef "size_type" to the writer to forward the user definable rapidjson::SizeType to the writer objects.
See issue #877 .