### PR TITLE
Fix -Werror=effc++ errors with GNU 6.3.1

### DIFF
--- a/example/simplepullreader/simplepullreader.cpp
+++ b/example/simplepullreader/simplepullreader.cpp
@@ -13,8 +13,8 @@ template <typename T> std::string stringify(T x) {
 }
 
 struct MyHandler {
-    const char* type;
-    std::string data;
+    const char* type = NULL;
+    std::string data = "";
     
     bool Null() { type = "Null"; data.clear(); return true; }
     bool Bool(bool b) { type = "Bool:"; data = b? "true": "false"; return true; }


### PR DESCRIPTION
Fix "'MyHandler::type’ should be initialized in the member
initialization list [-Werror=effc++]" errors.

https://github.com/miloyip/rapidjson/issues/874