### PR TITLE
Fix -Werror=effc++ errors with GNU 6.3.1

### DIFF
--- a/example/simplepullreader/simplepullreader.cpp
+++ b/example/simplepullreader/simplepullreader.cpp
@@ -16,6 +16,14 @@ struct MyHandler {
     const char* type;
     std::string data;
     
+    MyHandler() : type(), data() { Null(); }
+    MyHandler(const MyHandler& cpy) : type(cpy.type),data(cpy.data) {}
+    MyHandler& operator=(const MyHandler& cpy) {
+	type = cpy.type;
+	data = cpy.data;
+	return *this;
+    }
+
     bool Null() { type = "Null"; data.clear(); return true; }
     bool Bool(bool b) { type = "Bool:"; data = b? "true": "false"; return true; }
     bool Int(int i) { type = "Int:"; data = stringify(i); return true; }

--- a/example/simplepullreader/simplepullreader.cpp
+++ b/example/simplepullreader/simplepullreader.cpp
@@ -16,13 +16,7 @@ struct MyHandler {
     const char* type;
     std::string data;
     
-    MyHandler() : type(), data() { Null(); }
-    MyHandler(const MyHandler& cpy) : type(cpy.type),data(cpy.data) {}
-    MyHandler& operator=(const MyHandler& cpy) {
-	type = cpy.type;
-	data = cpy.data;
-	return *this;
-    }
+    MyHandler() : type(), data() {}
 
     bool Null() { type = "Null"; data.clear(); return true; }
     bool Bool(bool b) { type = "Bool:"; data = b? "true": "false"; return true; }
@@ -38,6 +32,9 @@ struct MyHandler {
     bool EndObject(SizeType memberCount) { type = "EndObject:"; data = stringify(memberCount); return true; }
     bool StartArray() { type = "StartArray"; data.clear(); return true; }
     bool EndArray(SizeType elementCount) { type = "EndArray:"; data = stringify(elementCount); return true; }
+private:
+    MyHandler(const MyHandler& noCopyConstruction);
+    MyHandler& operator=(const MyHandler& noAssignment);
 };
 
 int main() {


### PR DESCRIPTION
Fix "'MyHandler::type’ should be initialized in the member
initialization list [-Werror=effc++]" errors.

https://github.com/miloyip/rapidjson/issues/874