### PR TITLE
Fix a non-type template parameter type mismatch

### DIFF
--- a/include/rapidjson/rapidjson.h
+++ b/include/rapidjson/rapidjson.h
@@ -413,7 +413,7 @@ RAPIDJSON_NAMESPACE_END
 RAPIDJSON_NAMESPACE_BEGIN
 template <bool x> struct STATIC_ASSERTION_FAILURE;
 template <> struct STATIC_ASSERTION_FAILURE<true> { enum { value = 1 }; };
-template<int x> struct StaticAssertTest {};
+template <size_t x> struct StaticAssertTest {};
 RAPIDJSON_NAMESPACE_END
 
 #define RAPIDJSON_JOIN(X, Y) RAPIDJSON_DO_JOIN(X, Y)


### PR DESCRIPTION
This issues a warning in gcc7.

While compilers can certainly perform safe integer conversions at compile-time, this warning is not totally unreasonable, considering we added `<auto>` non-type template to C++17, which is both value-dependent and type-dependent, a main template that is "upgraded" from `<int>` to `<auto>` can have `X<0>` and `X<sizeof(char)>` as different specializations, so a type mismatch here is better be warned.

One the other hand I'm curious why we aren't using `static_assert`...
```
diff --git a/include/rapidjson/rapidjson.h b/include/rapidjson/rapidjson.h
index 19a30193..268fd47c 100644
--- a/include/rapidjson/rapidjson.h
+++ b/include/rapidjson/rapidjson.h
@@ -420,6 +420,9 @@ RAPIDJSON_NAMESPACE_END
 #define RAPIDJSON_DO_JOIN(X, Y) RAPIDJSON_DO_JOIN2(X, Y)
 #define RAPIDJSON_DO_JOIN2(X, Y) X##Y
 
+#if __cplusplus >= 201103L
+#define RAPIDJSON_STATIC_ASSERT(x) static_assert(x, #x)
+#else
 #if defined(__GNUC__)
 #define RAPIDJSON_STATIC_ASSERT_UNUSED_ATTRIBUTE __attribute__((unused))
 #else
@@ -439,6 +442,7 @@ RAPIDJSON_NAMESPACE_END
       sizeof(::RAPIDJSON_NAMESPACE::STATIC_ASSERTION_FAILURE<bool(x) >)> \
     RAPIDJSON_JOIN(StaticAssertTypedef, __LINE__) RAPIDJSON_STATIC_ASSERT_UNUSED_ATTRIBUTE
 #endif
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 // RAPIDJSON_LIKELY, RAPIDJSON_UNLIKELY
```
Works on my machine™.