### PR TITLE
Add kParsePartialFractionFlag

### DIFF
--- a/doc/dom.md
+++ b/doc/dom.md
@@ -119,6 +119,7 @@ Parse flags                   | Meaning
 `kParseNumbersAsStringsFlag`  | Parse numerical type values as strings.
 `kParseTrailingCommasFlag`    | Allow trailing commas at the end of objects and arrays (relaxed JSON syntax).
 `kParseNanAndInfFlag`         | Allow parsing `NaN`, `Inf`, `Infinity`, `-Inf` and `-Infinity` as `double` values (relaxed JSON syntax).
+`kParsePartialFractionFlag`   | Allow parsing fractions that begin with a `.` (e.g. `.123` or `123.`).
 
 By using a non-type template parameter, instead of a function parameter, C++ compiler can generate code which is optimized for specified combinations, improving speed, and reducing code size (if only using a single specialization). The downside is the flags needed to be determined in compile-time.
 

--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -155,6 +155,7 @@ enum ParseFlag {
     kParseNumbersAsStringsFlag = 64,    //!< Parse all numbers (ints/doubles) as strings.
     kParseTrailingCommasFlag = 128, //!< Allow trailing commas at the end of objects and arrays.
     kParseNanAndInfFlag = 256,      //!< Allow parsing NaN, Inf, Infinity, -Inf and -Infinity as doubles.
+    kParsePartialFractionFlag = 512,//!< Allow parsing fractions that begin or end with a dot.
     kParseDefaultFlags = RAPIDJSON_PARSE_DEFAULT_FLAGS  //!< Default parse flags. Can be customized by defining RAPIDJSON_PARSE_DEFAULT_FLAGS
 };
 
@@ -1529,7 +1530,8 @@ private:
                 RAPIDJSON_PARSE_ERROR(kParseErrorValueInvalid, s.Tell());
             }
         }
-        else
+        // Continue parsing if it looks like a partial fraction
+        else if (!((parseFlags & kParsePartialFractionFlag) && s.Peek() == '.'))
             RAPIDJSON_PARSE_ERROR(kParseErrorValueInvalid, s.Tell());
 
         // Parse 64bit int
@@ -1574,8 +1576,12 @@ private:
         if (Consume(s, '.')) {
             decimalPosition = s.Length();
 
-            if (RAPIDJSON_UNLIKELY(!(s.Peek() >= '0' && s.Peek() <= '9')))
-                RAPIDJSON_PARSE_ERROR(kParseErrorNumberMissFraction, s.Tell());
+            if (RAPIDJSON_UNLIKELY(!(s.Peek() >= '0' && s.Peek() <= '9'))) {
+                if (!(parseFlags & kParsePartialFractionFlag))
+                    RAPIDJSON_PARSE_ERROR(kParseErrorNumberMissFraction, s.Tell());
+                else if (!(s.Peek() == ',' || s.Peek() == '}' || s.Peek() == ']' || s.Peek() == '\0' || s.Peek() == 'e' || s.Peek() == 'E'))
+                    RAPIDJSON_PARSE_ERROR(kParseErrorValueInvalid, s.Tell());
+            }
 
             if (!useDouble) {
 #if RAPIDJSON_64BIT

--- a/test/unittest/readertest.cpp
+++ b/test/unittest/readertest.cpp
@@ -1892,4 +1892,60 @@ TEST(Reader, ParseNanAndInfinity) {
 #undef TEST_NAN_INF
 }
 
+TEST(Reader, ParsePartialFraction) {
+#define TEST_PARSE_PARTIAL_FRACTION(str, x) \
+    { \
+        StringStream s(str); \
+        ParseDoubleHandler h; \
+        Reader reader; \
+        ASSERT_EQ(kParseErrorNone, reader.Parse<kParsePartialFractionFlag>(s, h).Code()); \
+        internal::Double e(x), a(h.actual_); \
+        EXPECT_EQ(1u, h.step_); \
+        EXPECT_EQ(e.Sign(), a.Sign()); \
+        EXPECT_DOUBLE_EQ(x, h.actual_); \
+    }
+#define TEST_PARSE_PARTIAL_FRACTION_ERROR(errorCode, str, errorOffset) \
+    { \
+        char buffer[1001]; \
+        int streamPos = errorOffset; \
+        sprintf(buffer, "%s", str); \
+        InsituStringStream s(buffer); \
+        BaseReaderHandler<> h; \
+        Reader reader; \
+        EXPECT_FALSE(reader.Parse<kParsePartialFractionFlag>(s, h)); \
+        EXPECT_EQ(errorCode, reader.GetParseErrorCode()); \
+        EXPECT_EQ(errorOffset, reader.GetErrorOffset()); \
+        EXPECT_EQ(streamPos, s.Tell()); \
+    }
+    TEST_PARSE_PARTIAL_FRACTION("0.", 0.0);
+    TEST_PARSE_PARTIAL_FRACTION("-0.", -0.0);
+    TEST_PARSE_PARTIAL_FRACTION("1.", 1.0);
+    TEST_PARSE_PARTIAL_FRACTION("-1.", -1.0);
+    TEST_PARSE_PARTIAL_FRACTION("1.E10", 1E10);
+    TEST_PARSE_PARTIAL_FRACTION("1.e10", 1e10);
+    TEST_PARSE_PARTIAL_FRACTION("1.E+10", 1E+10);
+    TEST_PARSE_PARTIAL_FRACTION("1.E-10", 1E-10);
+    TEST_PARSE_PARTIAL_FRACTION("-1.E10", -1E10);
+    TEST_PARSE_PARTIAL_FRACTION("-1.e10", -1e10);
+    TEST_PARSE_PARTIAL_FRACTION("-1.E+10", -1E+10);
+    TEST_PARSE_PARTIAL_FRACTION("-1.E-10", -1E-10);
+    TEST_PARSE_PARTIAL_FRACTION("123.", 123.0);
+    TEST_PARSE_PARTIAL_FRACTION(".123", 0.123);
+    TEST_PARSE_PARTIAL_FRACTION("-.123", -0.123);
+    TEST_PARSE_PARTIAL_FRACTION(".E10", 0.0);
+    TEST_PARSE_PARTIAL_FRACTION(".e10", 0.0);
+    TEST_PARSE_PARTIAL_FRACTION(".E+10", 0.0);
+    TEST_PARSE_PARTIAL_FRACTION(".E-10", 0.0);
+    TEST_PARSE_PARTIAL_FRACTION("-.E10", -0.0);
+    TEST_PARSE_PARTIAL_FRACTION("-.e10", -0.0);
+    TEST_PARSE_PARTIAL_FRACTION("-.E+10", -0.0);
+    TEST_PARSE_PARTIAL_FRACTION("-.E-10", -0.0);
+    TEST_PARSE_PARTIAL_FRACTION(".123e10", 1.23e9);
+    TEST_PARSE_PARTIAL_FRACTION("-.123e10", -1.23e9);
+    TEST_PARSE_PARTIAL_FRACTION(".", 0.0);
+    TEST_PARSE_PARTIAL_FRACTION("-.", -0.0);
+    TEST_PARSE_PARTIAL_FRACTION_ERROR(kParseErrorValueInvalid, ".a123", 1);
+    TEST_PARSE_PARTIAL_FRACTION_ERROR(kParseErrorValueInvalid, "-.a123", 2);
+}
+
 RAPIDJSON_DIAG_POP


### PR DESCRIPTION
This flag relaxes the requirements on double parsing so that fractions
can begin with a dot or have a dot without fraction digits.

This is related to some of the points in #36

I am not too keen on the flag name but I don't have a more inspired proposal.