### PR TITLE
Intel C++ Compiler preprocessor guard for #pragma intrinsic - diyfp.h

### DIFF
--- a/include/rapidjson/internal/diyfp.h
+++ b/include/rapidjson/internal/diyfp.h
@@ -21,7 +21,7 @@
 
 #include "../rapidjson.h"
 
-#if defined(_MSC_VER) && defined(_M_AMD64)
+#if defined(_MSC_VER) && defined(_M_AMD64) && !defined(__INTEL_COMPILER)
 #include <intrin.h>
 #pragma intrinsic(_BitScanReverse64)
 #pragma intrinsic(_umul128)


### PR DESCRIPTION
To avoid Intel C++ Compiler #1879 warnings:
warning #1879: unimplemented pragma ignored: #pragma intrinsic(_BitScanReverse64)
warning #1879: unimplemented pragma ignored: #pragma intrinsic(_umul128)

See topic:
https://software.intel.com/en-us/forums/intel-c-compiler/topic/405440