### PR TITLE
Fixed #985 : Unittest failed with MinGWx64. And few small improvement…

### DIFF
--- a/test/unittest/ostreamwrappertest.cpp
+++ b/test/unittest/ostreamwrappertest.cpp
@@ -69,14 +69,15 @@ static void TestFileStream() {
 
     const char* s = "Hello World!\n";
     {
-        ofstream ofs(filename, ios::out | ios::binary);
-        BasicOStreamWrapper<ofstream> osw(ofs);
+        FileStreamType ofs(filename, ios::out | ios::binary);
+        BasicOStreamWrapper<FileStreamType> osw(ofs);
         for (const char* p = s; *p; p++)
             osw.Put(*p);
         osw.Flush();
     }
 
     fp = fopen(filename, "r");
+	ASSERT_TRUE( fp != NULL );
     for (const char* p = s; *p; p++)
         EXPECT_EQ(*p, static_cast<char>(fgetc(fp)));
     fclose(fp);

--- a/test/unittest/prettywritertest.cpp
+++ b/test/unittest/prettywritertest.cpp
@@ -167,6 +167,7 @@ TEST(PrettyWriter, OStreamWrapper) {
 TEST(PrettyWriter, FileWriteStream) {
     char filename[L_tmpnam];
     FILE* fp = TempFile(filename);
+    ASSERT_TRUE(fp!=NULL);
     char buffer[16];
     FileWriteStream os(fp, buffer, sizeof(buffer));
     PrettyWriter<FileWriteStream> writer(os);

--- a/test/unittest/unittest.h
+++ b/test/unittest/unittest.h
@@ -78,7 +78,7 @@ inline Ch* StrDup(const Ch* str) {
 }
 
 inline FILE* TempFile(char *filename) {
-#ifdef _MSC_VER
+#if defined(__WIN32__) || defined(_MSC_VER)
     filename = tmpnam(filename);
 
     // For Visual Studio, tmpnam() adds a backslash in front. Remove it.


### PR DESCRIPTION
… were done while looking for mistakes.

Problem was because of Windows uses backslashes '\\', not Unix '/'