### PR TITLE
ParseResult: improve bool conversion and add operator!=

### DIFF
--- a/include/rapidjson/error/error.h
+++ b/include/rapidjson/error/error.h
@@ -104,6 +104,8 @@ enum ParseErrorCode {
     \see GenericReader::Parse, GenericDocument::Parse
 */
 struct ParseResult {
+    //!! Unspecified boolean type
+    typedef bool (ParseResult::*BooleanType)() const;
 public:
     //! Default constructor, no error.
     ParseResult() : code_(kParseErrorNone), offset_(0) {}
@@ -115,14 +117,18 @@ public:
     //! Get the error offset, if \ref IsError(), 0 otherwise.
     size_t Offset() const { return offset_; }
 
-    //! Conversion to \c bool, returns \c true, iff !\ref IsError().
-    operator bool() const { return !IsError(); }
+    //! Explicit conversion to \c bool, returns \c true, iff !\ref IsError().
+    operator BooleanType() const { return !IsError() ? &ParseResult::IsError : NULL; }
     //! Whether the result is an error.
     bool IsError() const { return code_ != kParseErrorNone; }
 
     bool operator==(const ParseResult& that) const { return code_ == that.code_; }
     bool operator==(ParseErrorCode code) const { return code_ == code; }
     friend bool operator==(ParseErrorCode code, const ParseResult & err) { return code == err.code_; }
+
+    bool operator!=(const ParseResult& that) const { return !(*this == that); }
+    bool operator!=(ParseErrorCode code) const { return !(*this == code); }
+    friend bool operator!=(ParseErrorCode code, const ParseResult & err) { return err != code; }
 
     //! Reset error code.
     void Clear() { Set(kParseErrorNone); }

--- a/test/unittest/documenttest.cpp
+++ b/test/unittest/documenttest.cpp
@@ -128,8 +128,14 @@ TEST(Document, UnchangedOnParseError) {
     Document doc;
     doc.SetArray().PushBack(0, doc.GetAllocator());
 
+    ParseResult noError;
+    EXPECT_TRUE(noError);
+
     ParseResult err = doc.Parse("{]");
     EXPECT_TRUE(doc.HasParseError());
+    EXPECT_NE(err, noError);
+    EXPECT_NE(err.Code(), noError);
+    EXPECT_NE(noError, doc.GetParseError());
     EXPECT_EQ(err.Code(), doc.GetParseError());
     EXPECT_EQ(err.Offset(), doc.GetErrorOffset());
     EXPECT_TRUE(doc.IsArray());
@@ -138,6 +144,9 @@ TEST(Document, UnchangedOnParseError) {
     err = doc.Parse("{}");
     EXPECT_FALSE(doc.HasParseError());
     EXPECT_FALSE(err.IsError());
+    EXPECT_TRUE(err);
+    EXPECT_EQ(err, noError);
+    EXPECT_EQ(err.Code(), noError);
     EXPECT_EQ(err.Code(), doc.GetParseError());
     EXPECT_EQ(err.Offset(), doc.GetErrorOffset());
     EXPECT_TRUE(doc.IsObject());
@@ -488,15 +497,19 @@ TYPED_TEST(DocumentMove, MoveConstructorParseError) {
     a.Parse("{ 4 = 4]");
     ParseResult error(a.GetParseError(), a.GetErrorOffset());
     EXPECT_TRUE(a.HasParseError());
+    EXPECT_NE(error, noError);
+    EXPECT_NE(error.Code(), noError);
     EXPECT_NE(error.Code(), noError.Code());
     EXPECT_NE(error.Offset(), noError.Offset());
 
     D b(std::move(a));
     EXPECT_FALSE(a.HasParseError());
     EXPECT_TRUE(b.HasParseError());
+    EXPECT_EQ(a.GetParseError(), noError);
     EXPECT_EQ(a.GetParseError(), noError.Code());
-    EXPECT_EQ(b.GetParseError(), error.Code());
     EXPECT_EQ(a.GetErrorOffset(), noError.Offset());
+    EXPECT_EQ(b.GetParseError(), error);
+    EXPECT_EQ(b.GetParseError(), error.Code());
     EXPECT_EQ(b.GetErrorOffset(), error.Offset());
 
     D c(std::move(b));


### PR DESCRIPTION
As reported by @OlafvdSpek in #989, the implicit conversion to `bool` can lead to accidentally compiling expressions.  In addition to the mentioned arithmetic expressions, also using `operator!=` leads to wrong results:
```cpp
  ParseResult err = doc.Parse("{]");
  if (err != kParseErrorNone) {
    // missed! (err --> false, kParseErrorNone --> 0 --> equal!)
  }
```

Instead of using an `explicit operator bool` (requires C++11), this PR proposes using the safe-bool idiom.  For completeness, the various `operator!=` overloads are added as well.