### PR TITLE
Travis: Switch to Ubuntu 14.04 (Trusty)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: required
-dist: precise
+dist: trusty
+group: edge
 
 language: cpp
 cache:


### PR DESCRIPTION
This is an experiment to move the Travis setup to the new Ubuntu 14.04 (Trusty) images, see
* https://docs.travis-ci.com/user/trusty-ci-environment
* https://blog.travis-ci.com/2017-06-19-trusty-updates-2017-Q2

Ideally, this also helps with #993 by using the more recent version of Doxygen from Trusty.