### PR TITLE
travis-doxygen.sh: upgrade to Doxygen 1.8.13

### DIFF
--- a/travis-doxygen.sh
+++ b/travis-doxygen.sh
@@ -4,10 +4,9 @@
 
 set -e
 
-DOXYGEN_VER=doxygen-1.8.7
+DOXYGEN_VER=doxygen-1.8.13
 DOXYGEN_TAR=${DOXYGEN_VER}.linux.bin.tar.gz
 DOXYGEN_URL="http://ftp.stack.nl/pub/users/dimitri/${DOXYGEN_TAR}"
-DOXYGEN_BIN="/usr/local/bin/doxygen"
 
 : ${GITHUB_REPO:="miloyip/rapidjson"}
 GITHUB_HOST="github.com"
@@ -66,7 +65,7 @@ gh_pages_prepare()
 	[ ! -d "html" ] || \
 		abort "Doxygen target directory already exists."
 	git --version
-	git clone -b gh-pages "${GITHUB_CLONE}" html
+	git clone --single-branch -b gh-pages "${GITHUB_CLONE}" html
 	cd html
 	# setup git config (with defaults)
 	git config user.name "${GIT_NAME-travis}"


### PR DESCRIPTION
This is a second attempt to close #993 (pre-tested only by running the `travis-doxygen.sh` script locally):

 * Upgrade to the latest Doxygen version 1.8.13
 * Drop unused variable `DOXYGEN_BIN`
 * Reenable `--single-branch` (travis-ci/travis-ci#5225 is closed)