### PR TITLE
GenericStringRef: move assert out of expression

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -308,7 +308,7 @@ struct GenericStringRef {
      */
 #endif
     explicit GenericStringRef(const CharType* str)
-        : s(str), length(((RAPIDJSON_ASSERT(str != 0)), internal::StrLen(str))) {}
+        : s(str), length(NotNullStrLen(str)) {}
 
     //! Create constant string reference from pointer and length
 #ifndef __clang__ // -Wdocumentation
@@ -331,6 +331,11 @@ struct GenericStringRef {
     const SizeType length; //!< length of the string (excluding the trailing NULL terminator)
 
 private:
+    SizeType NotNullStrLen(const CharType* str) {
+        RAPIDJSON_ASSERT(str != 0);
+        return internal::StrLen(str);
+    }
+
     /// Empty string - used when passing in a NULL pointer
     static const Ch emptyString[];
 


### PR DESCRIPTION
As mentioned by @sagaceilo in https://github.com/miloyip/rapidjson/commit/47c3c1ec9f5c3724c5befb42f8323e760acc1f69#commitcomment-23018046, some assert implementations don't support assertions inside of expressions.

As `internal::StrLen` should continue relying on the not-null guarantee, I moved the `RAPIDJSON_ASSERT+StrLen` sequence into a local function in `GenericStringRef` instead.