### PR TITLE
MemoryPoolAllocator: fix reporting incorrect size.

### DIFF
--- a/include/rapidjson/allocators.h
+++ b/include/rapidjson/allocators.h
@@ -168,7 +168,7 @@ public:
     size_t Size() const {
         size_t size = 0;
         for (ChunkHeader* c = chunkHead_; c != 0; c = c->next)
-            size += sizeof(ChunkHeader) + c->size;
+            size += RAPIDJSON_ALIGN(sizeof(ChunkHeader)) + c->size;
         return size;
     }
 

--- a/include/rapidjson/allocators.h
+++ b/include/rapidjson/allocators.h
@@ -166,9 +166,9 @@ public:
     /*! \return total used bytes.
     */
     size_t Size() const {
-        size_t size = 0;
+        size_t size = RAPIDJSON_ALIGN(sizeof(ChunkHeader));
         for (ChunkHeader* c = chunkHead_; c != 0; c = c->next)
-            size += RAPIDJSON_ALIGN(sizeof(ChunkHeader)) + c->size;
+            size += c->size;
         return size;
     }
 

--- a/include/rapidjson/allocators.h
+++ b/include/rapidjson/allocators.h
@@ -168,7 +168,7 @@ public:
     size_t Size() const {
         size_t size = 0;
         for (ChunkHeader* c = chunkHead_; c != 0; c = c->next)
-            size += RAPIDJSON_ALIGN(sizeof(ChunkHeader)) + c->size;
+            size += sizeof(ChunkHeader) + c->size;
         return size;
     }
 
@@ -178,11 +178,9 @@ public:
             return NULL;
 
         size = RAPIDJSON_ALIGN(size);
-        if (chunkHead_ == 0 || chunkHead_->size + size > chunkHead_->capacity) {
-            size = chunk_capacity_ > size ? chunk_capacity_ : size;
-            if (!AddChunk(size))
+        if (chunkHead_ == 0 || chunkHead_->size + size > chunkHead_->capacity)
+            if (!AddChunk(chunk_capacity_ > size ? chunk_capacity_ : size))
                 return NULL;
-        }
 
         void *buffer = reinterpret_cast<char *>(chunkHead_) + RAPIDJSON_ALIGN(sizeof(ChunkHeader)) + chunkHead_->size;
         chunkHead_->size += size;

--- a/include/rapidjson/allocators.h
+++ b/include/rapidjson/allocators.h
@@ -168,7 +168,7 @@ public:
     size_t Size() const {
         size_t size = 0;
         for (ChunkHeader* c = chunkHead_; c != 0; c = c->next)
-            size += sizeof(ChunkHeader) + c->size;
+            size += RAPIDJSON_ALIGN(sizeof(ChunkHeader)) + c->size;
         return size;
     }
 
@@ -178,9 +178,11 @@ public:
             return NULL;
 
         size = RAPIDJSON_ALIGN(size);
-        if (chunkHead_ == 0 || chunkHead_->size + size > chunkHead_->capacity)
-            if (!AddChunk(chunk_capacity_ > size ? chunk_capacity_ : size))
+        if (chunkHead_ == 0 || chunkHead_->size + size > chunkHead_->capacity) {
+            size = chunk_capacity_ > size ? chunk_capacity_ : size;
+            if (!AddChunk(size))
                 return NULL;
+        }
 
         void *buffer = reinterpret_cast<char *>(chunkHead_) + RAPIDJSON_ALIGN(sizeof(ChunkHeader)) + chunkHead_->size;
         chunkHead_->size += size;

--- a/include/rapidjson/allocators.h
+++ b/include/rapidjson/allocators.h
@@ -168,7 +168,7 @@ public:
     size_t Size() const {
         size_t size = 0;
         for (ChunkHeader* c = chunkHead_; c != 0; c = c->next)
-            size += c->size;
+            size += sizeof(ChunkHeader) + c->size;
         return size;
     }
 


### PR DESCRIPTION
During 'AddChunk', the amount allocated is the requested capacty plus the
size of a ChunkHeader. The additional size of the ChunkHeader is not taken
into account when the size is reported in the 'Size' method. If the
difference between the buffer size and the allocated size is less than the
size of a ChunkHeader, the user will allocate off the heap each time and
not know to increase the buffer's size.