### PR TITLE
Issue #1024: SJSON support.

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -21,6 +21,7 @@ set(EXAMPLES
     simplereader
     simplepullreader
     simplewriter
+    sjson
     tutorial)
     
 include_directories("../include/")

--- a/example/sjson/sjson.cpp
+++ b/example/sjson/sjson.cpp
@@ -1,0 +1,75 @@
+// JSON to SJSON conversion utility.
+// SJSON is an Autodesk format, which has some exceptions and simplifications to the json format.
+// http://help.autodesk.com/view/Stingray/ENU/?guid=__stingray_help_managing_content_sjson_html
+// This example parses JSON or SJSON text from stdin with validation, 
+// and converts to SJSON or JSON format to stdout.
+
+#include "rapidjson/reader.h"
+#include "rapidjson/prettywriter.h"
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/filereadstream.h"
+#include "rapidjson/filewritestream.h"
+#include "rapidjson/error/en.h"
+#include <cstdio>
+
+using namespace rapidjson;
+
+template<typename ReaderType, typename WriterType> 
+int performParsing(ReaderType& reader, WriterType& writer, FileReadStream& is) {
+    // JSON reader parse from the input stream and let writer generate the output.
+    if (!reader.Parse<kParseSJSONDefaultFlags>(is, writer)) {
+        fprintf(stderr, "\nError(%u): %s\n", static_cast<unsigned>(reader.GetErrorOffset()), GetParseError_En(reader.GetParseErrorCode()));
+        return 1;
+    }
+    return 0;
+}
+
+int main(int argc, char* argv[]) {
+    bool json_output = true;
+    bool pretty_output = true;
+    // Read command line arguments.
+    for (int i = 0; i < argc; ++i) {
+        if (!strcmp(argv[i], "--sjson-output"))
+            json_output = false;
+        else if (!strcmp(argv[i], "--no-pretty"))
+            pretty_output = true;
+        else if (!strcmp(argv[i], "--help")) {
+            fprintf(stdout, "--sjson-output  Output file is in written with sjson simplifications (not compatible with json-only readers).\n");
+            fprintf(stdout, "--no-pretty     Output is condensed (otherwise, PrettyWriter is used).\n");
+            fprintf(stdout, "--help          Write this help and exit.\n");
+            return 0;
+        }
+    }
+
+    // Prepare JSON reader and input stream.
+    Reader reader;
+    char readBuffer[65536];
+    FileReadStream is(stdin, readBuffer, sizeof(readBuffer));
+
+    // Prepare JSON writer and output stream.
+    char writeBuffer[65536];
+    FileWriteStream os(stdout, writeBuffer, sizeof(writeBuffer));
+
+    if (!json_output) {
+        if (pretty_output) {
+            PrettyWriter<FileWriteStream, UTF8<>, UTF8<>, CrtAllocator, kWriteDefaultSJSONFlags> writer(os);
+            return performParsing(reader, writer, is);
+        }
+        else {
+            Writer<FileWriteStream, UTF8<>, UTF8<>, CrtAllocator, kWriteDefaultSJSONFlags> writer(os);
+            return performParsing(reader, writer, is);
+        }
+    }
+    else {
+        if (pretty_output) {
+            PrettyWriter<FileWriteStream> writer(os);
+            return performParsing(reader, writer, is);
+        }
+        else {
+            Writer<FileWriteStream> writer(os);
+            return performParsing(reader, writer, is);
+        }
+    }
+
+    return 0;
+}

--- a/include/rapidjson/error/en.h
+++ b/include/rapidjson/error/en.h
@@ -44,6 +44,7 @@ inline const RAPIDJSON_ERROR_CHARTYPE* GetParseError_En(ParseErrorCode parseErro
     
         case kParseErrorObjectMissName:                 return RAPIDJSON_ERROR_STRING("Missing a name for object member.");
         case kParseErrorObjectMissColon:                return RAPIDJSON_ERROR_STRING("Missing a colon after a name of object member.");
+        case kParseErrorObjectMissEqual:                return RAPIDJSON_ERROR_STRING("Missing an equal sign after a name of object member.");
         case kParseErrorObjectMissCommaOrCurlyBracket:  return RAPIDJSON_ERROR_STRING("Missing a comma or '}' after an object member.");
     
         case kParseErrorArrayMissCommaOrSquareBracket:  return RAPIDJSON_ERROR_STRING("Missing a comma or ']' after an array element.");

--- a/include/rapidjson/error/error.h
+++ b/include/rapidjson/error/error.h
@@ -71,6 +71,7 @@ enum ParseErrorCode {
 
     kParseErrorObjectMissName,                  //!< Missing a name for object member.
     kParseErrorObjectMissColon,                 //!< Missing a colon after a name of object member.
+    kParseErrorObjectMissEqual,                 //!< Missing a equal after a name of object member (\sa kParseEqualReplaceColon).
     kParseErrorObjectMissCommaOrCurlyBracket,   //!< Missing a comma or '}' after an object member.
 
     kParseErrorArrayMissCommaOrSquareBracket,   //!< Missing a comma or ']' after an array element.

--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -24,6 +24,7 @@
 #include "internal/stack.h"
 #include "internal/strtod.h"
 #include <limits>
+#include <locale>
 
 #if defined(RAPIDJSON_SIMD) && defined(_MSC_VER)
 #include <intrin.h>
@@ -155,7 +156,12 @@ enum ParseFlag {
     kParseNumbersAsStringsFlag = 64,    //!< Parse all numbers (ints/doubles) as strings.
     kParseTrailingCommasFlag = 128, //!< Allow trailing commas at the end of objects and arrays.
     kParseNanAndInfFlag = 256,      //!< Allow parsing NaN, Inf, Infinity, -Inf and -Infinity as doubles.
-    kParseDefaultFlags = RAPIDJSON_PARSE_DEFAULT_FLAGS  //!< Default parse flags. Can be customized by defining RAPIDJSON_PARSE_DEFAULT_FLAGS
+    kParseEqualReplaceColon = 512,  //!< sjson: = is used to define key-value pairs instead of the colon :.
+    kParseImplicitTopLevel = 1024,  //!< sjson: Each SJSON file is always interpreted as a definition for a single object.
+    kParseKeyQuotesOptional = 2048, //!< sjson: Quotes around string keys in key-value pairs are optional, unless you need the key to contain either spaces or the equal sign =.
+    kParseCommasOptional = 4096,    //!< sjson: Commas are optional in object and array definitions.
+    kParseDefaultFlags = RAPIDJSON_PARSE_DEFAULT_FLAGS,  //!< Default parse flags. Can be customized by defining RAPIDJSON_PARSE_DEFAULT_FLAGS
+    kParseSJSONDefaultFlags = kParseCommentsFlag | kParseEqualReplaceColon | kParseImplicitTopLevel | kParseKeyQuotesOptional | kParseCommasOptional //!< Default flags for parsing sjson. The supplied flags are required, but others could be added.
 };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -571,8 +577,12 @@ public:
             RAPIDJSON_PARSE_ERROR_EARLY_RETURN(parseResult_);
         }
         else {
-            ParseValue<parseFlags>(is, handler);
-            RAPIDJSON_PARSE_ERROR_EARLY_RETURN(parseResult_);
+            if (parseFlags & kParseImplicitTopLevel) {
+                ParseObject<parseFlags>(is, handler, true);
+            } else {
+                ParseValue<parseFlags>(is, handler);
+                RAPIDJSON_PARSE_ERROR_EARLY_RETURN(parseResult_);
+            }
 
             if (!(parseFlags & kParseStopWhenDoneFlag)) {
                 SkipWhitespaceAndComments<parseFlags>(is);
@@ -736,10 +746,12 @@ private:
 
     // Parse object: { string : value, ... }
     template<unsigned parseFlags, typename InputStream, typename Handler>
-    void ParseObject(InputStream& is, Handler& handler) {
-        RAPIDJSON_ASSERT(is.Peek() == '{');
-        is.Take();  // Skip '{'
-
+    void ParseObject(InputStream& is, Handler& handler, bool top_level = false) {
+        top_level; // avoid warning.
+        if (!((parseFlags & kParseImplicitTopLevel) && top_level)) {
+            RAPIDJSON_ASSERT(is.Peek() == '{');
+            is.Take();  // Skip '{'
+        }
         if (RAPIDJSON_UNLIKELY(!handler.StartObject()))
             RAPIDJSON_PARSE_ERROR(kParseErrorTermination, is.Tell());
 
@@ -753,7 +765,7 @@ private:
         }
 
         for (SizeType memberCount = 0;;) {
-            if (RAPIDJSON_UNLIKELY(is.Peek() != '"'))
+            if (RAPIDJSON_UNLIKELY(is.Peek() != '"') && !(parseFlags & kParseKeyQuotesOptional))
                 RAPIDJSON_PARSE_ERROR(kParseErrorObjectMissName, is.Tell());
 
             ParseString<parseFlags>(is, handler, true);
@@ -762,8 +774,16 @@ private:
             SkipWhitespaceAndComments<parseFlags>(is);
             RAPIDJSON_PARSE_ERROR_EARLY_RETURN_VOID;
 
-            if (RAPIDJSON_UNLIKELY(!Consume(is, ':')))
-                RAPIDJSON_PARSE_ERROR(kParseErrorObjectMissColon, is.Tell());
+            if (parseFlags & kParseEqualReplaceColon) {
+                switch (is.Peek()) {
+                    case '=': case ':': is.Take(); break;
+                    default: RAPIDJSON_PARSE_ERROR(kParseErrorObjectMissEqual, is.Tell()); break;
+                }
+            } 
+            else {
+                if (RAPIDJSON_UNLIKELY(!Consume(is, ':')))
+                    RAPIDJSON_PARSE_ERROR(kParseErrorObjectMissColon, is.Tell());
+            }
 
             SkipWhitespaceAndComments<parseFlags>(is);
             RAPIDJSON_PARSE_ERROR_EARLY_RETURN_VOID;
@@ -788,7 +808,17 @@ private:
                         RAPIDJSON_PARSE_ERROR(kParseErrorTermination, is.Tell());
                     return;
                 default:
-                    RAPIDJSON_PARSE_ERROR(kParseErrorObjectMissCommaOrCurlyBracket, is.Tell()); break; // This useless break is only for making warning and coverage happy
+                    if (!(((parseFlags & kParseImplicitTopLevel) && top_level) ||
+                          (parseFlags & kParseCommasOptional))) {
+                        RAPIDJSON_PARSE_ERROR(kParseErrorObjectMissCommaOrCurlyBracket, is.Tell());
+                    }
+                    // EOF with implicit top-level.
+                    if (parseFlags & kParseImplicitTopLevel && top_level && !is.Peek()) {
+                        if (RAPIDJSON_UNLIKELY(!handler.EndObject(memberCount)))
+                            RAPIDJSON_PARSE_ERROR(kParseErrorTermination, is.Tell());
+                        return;
+                    }
+                    break; // This useless break is only for making warning and coverage happy
             }
 
             if (parseFlags & kParseTrailingCommasFlag) {
@@ -836,6 +866,9 @@ private:
                 if (RAPIDJSON_UNLIKELY(!handler.EndArray(elementCount)))
                     RAPIDJSON_PARSE_ERROR(kParseErrorTermination, is.Tell());
                 return;
+            }
+            else if (parseFlags & kParseCommasOptional) {
+
             }
             else
                 RAPIDJSON_PARSE_ERROR(kParseErrorArrayMissCommaOrSquareBracket, is.Tell());
@@ -959,13 +992,21 @@ private:
         internal::StreamLocalCopy<InputStream> copy(is);
         InputStream& s(copy.s);
 
-        RAPIDJSON_ASSERT(s.Peek() == '\"');
-        s.Take();  // Skip '\"'
+        bool end_quote = true;
+        if (isKey && (parseFlags & kParseKeyQuotesOptional)) {
+            if (s.Peek() == '\"')
+                s.Take(); // Skip '\"'
+            else
+                end_quote = false;
+        } else {
+            RAPIDJSON_ASSERT(s.Peek() == '\"');
+            s.Take();  // Skip '\"'
+        }
 
         bool success = false;
         if (parseFlags & kParseInsituFlag) {
             typename InputStream::Ch *head = s.PutBegin();
-            ParseStringToStream<parseFlags, SourceEncoding, SourceEncoding>(s, s);
+            ParseStringToStream<parseFlags, SourceEncoding, SourceEncoding>(s, s, end_quote);
             RAPIDJSON_PARSE_ERROR_EARLY_RETURN_VOID;
             size_t length = s.PutEnd(head) - 1;
             RAPIDJSON_ASSERT(length <= 0xFFFFFFFF);
@@ -974,7 +1015,7 @@ private:
         }
         else {
             StackStream<typename TargetEncoding::Ch> stackStream(stack_);
-            ParseStringToStream<parseFlags, SourceEncoding, TargetEncoding>(s, stackStream);
+            ParseStringToStream<parseFlags, SourceEncoding, TargetEncoding>(s, stackStream, end_quote);
             RAPIDJSON_PARSE_ERROR_EARLY_RETURN_VOID;
             SizeType length = static_cast<SizeType>(stackStream.Length()) - 1;
             const typename TargetEncoding::Ch* const str = stackStream.Pop();
@@ -987,7 +1028,7 @@ private:
     // Parse string to an output is
     // This function handles the prefix/suffix double quotes, escaping, and optional encoding validation.
     template<unsigned parseFlags, typename SEncoding, typename TEncoding, typename InputStream, typename OutputStream>
-    RAPIDJSON_FORCEINLINE void ParseStringToStream(InputStream& is, OutputStream& os) {
+    RAPIDJSON_FORCEINLINE void ParseStringToStream(InputStream& is, OutputStream& os, bool end_quote = true) {
 //!@cond RAPIDJSON_HIDDEN_FROM_DOXYGEN
 #define Z16 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
         static const char escape[256] = {
@@ -1036,6 +1077,11 @@ private:
             else if (RAPIDJSON_UNLIKELY(c == '"')) {    // Closing double quote
                 is.Take();
                 os.Put('\0');   // null-terminate the string
+                return;
+            }
+            else if (!end_quote && (c == ' ' || c == '\n' || c == '\r' || c == '\t' || c == 0 || ((parseFlags & kParseEqualReplaceColon) ? c == '=' : c == ':'))) {
+                // if no end quote is expected, a space or delimiter (= or :) will end the string
+                os.Put('\0');
                 return;
             }
             else if (RAPIDJSON_UNLIKELY(static_cast<unsigned>(c) < 0x20)) { // RFC 4627: unescaped = %x20-21 / %x23-5B / %x5D-10FFFF

--- a/include/rapidjson/writer.h
+++ b/include/rapidjson/writer.h
@@ -68,7 +68,12 @@ enum WriteFlag {
     kWriteNoFlags = 0,              //!< No flags are set.
     kWriteValidateEncodingFlag = 1, //!< Validate encoding of JSON strings.
     kWriteNanAndInfFlag = 2,        //!< Allow writing of Infinity, -Infinity and NaN.
-    kWriteDefaultFlags = RAPIDJSON_WRITE_DEFAULT_FLAGS  //!< Default write flags. Can be customized by defining RAPIDJSON_WRITE_DEFAULT_FLAGS
+    kWriteImplicitTopLevel = 4,     //!< sjson: Do not write top-level object brackets.
+    kWriteOmitKeyQuotes = 8,        //!< sjson: Omit quotes around keys (except if they contain spaces or equal)
+    kWriteEqualReplaceColon = 16,   //!< sjson: = is used to define key-value pairs instead of the colon :
+    kWriteCommasOmitted = 32,       //!< sjson: Commas are optional in object and array definitions (spaces used instead).
+    kWriteDefaultFlags = RAPIDJSON_WRITE_DEFAULT_FLAGS, //!< Default write flags. Can be customized by defining RAPIDJSON_WRITE_DEFAULT_FLAGS
+    kWriteDefaultSJSONFlags = kWriteImplicitTopLevel | kWriteOmitKeyQuotes | kWriteEqualReplaceColon | kWriteCommasOmitted //!< Default write flags for sjson. Since sjson reading is compatible json, these aren't strictly necessary.
 };
 
 //! JSON writer
@@ -201,11 +206,11 @@ public:
         return EndValue(WriteString(str, length));
     }
 
-    bool String(const Ch* str, SizeType length, bool copy = false) {
+    bool String(const Ch* str, SizeType length, bool copy = false, bool key = false) {
         RAPIDJSON_ASSERT(str != 0);
         (void)copy;
         Prefix(kStringType);
-        return EndValue(WriteString(str, length));
+        return EndValue(WriteString(str, length, key));
     }
 
 #if RAPIDJSON_HAS_STDSTRING
@@ -220,7 +225,7 @@ public:
         return WriteStartObject();
     }
 
-    bool Key(const Ch* str, SizeType length, bool copy = false) { return String(str, length, copy); }
+    bool Key(const Ch* str, SizeType length, bool copy = false) { return String(str, length, copy, true); }
 
 #if RAPIDJSON_HAS_STDSTRING
     bool Key(const std::basic_string<Ch>& str)
@@ -375,7 +380,8 @@ protected:
         return true;
     }
 
-    bool WriteString(const Ch* str, SizeType length)  {
+    bool WriteString(const Ch* str, SizeType length, bool key = false)  {
+        (key); // avoid warning.
         static const typename OutputStream::Ch hexDigits[16] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
         static const char escape[256] = {
 #define Z16 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
@@ -390,11 +396,13 @@ protected:
         };
 
         if (TargetEncoding::supportUnicode)
-            PutReserve(*os_, 2 + length * 6); // "\uxxxx..."
+            PutReserve(*os_, ((!(writeFlags & kWriteOmitKeyQuotes) || key) ? 2 : 0) + length* 6); // "\uxxxx..."
         else
-            PutReserve(*os_, 2 + length * 12);  // "\uxxxx\uyyyy..."
+            PutReserve(*os_, ((!(writeFlags & kWriteOmitKeyQuotes) || key) ? 2 : 0) + length * 12);  // "\uxxxx\uyyyy..."
 
-        PutUnsafe(*os_, '\"');
+        if (!(writeFlags & kWriteOmitKeyQuotes) || !key)
+            PutUnsafe(*os_, '\"');
+
         GenericStringStream<SourceEncoding> is(str);
         while (ScanWriteUnescapedString(is, length)) {
             const Ch c = is.Peek();
@@ -445,7 +453,9 @@ protected:
                 Transcoder<SourceEncoding, TargetEncoding>::TranscodeUnsafe(is, *os_))))
                 return false;
         }
-        PutUnsafe(*os_, '\"');
+
+        if (!(writeFlags & kWriteOmitKeyQuotes) || !key)
+            PutUnsafe(*os_, '\"');
         return true;
     }
 
@@ -453,8 +463,18 @@ protected:
         return RAPIDJSON_LIKELY(is.Tell() < length);
     }
 
-    bool WriteStartObject() { os_->Put('{'); return true; }
-    bool WriteEndObject()   { os_->Put('}'); return true; }
+    bool WriteStartObject() 
+    { 
+        if (!(writeFlags & kWriteImplicitTopLevel) || level_stack_.GetSize() > sizeof(Level))
+            os_->Put('{'); 
+        return true; 
+    }
+    bool WriteEndObject()   
+    { 
+        if (!(writeFlags & kWriteImplicitTopLevel) || level_stack_.GetSize() > sizeof(Level))
+            os_->Put('}');
+        return true; 
+    }
     bool WriteStartArray()  { os_->Put('['); return true; }
     bool WriteEndArray()    { os_->Put(']'); return true; }
 
@@ -472,10 +492,17 @@ protected:
         if (RAPIDJSON_LIKELY(level_stack_.GetSize() != 0)) { // this value is not at root
             Level* level = level_stack_.template Top<Level>();
             if (level->valueCount > 0) {
-                if (level->inArray) 
-                    os_->Put(','); // add comma if it is not the first element in array
-                else  // in object
-                    os_->Put((level->valueCount % 2 == 0) ? ',' : ':');
+                if (level->inArray)
+                    if (writeFlags & kWriteCommasOmitted)
+                        os_->Put(' ');
+                    else
+                        os_->Put(','); // add comma if it is not the first element in array
+                else { // in object
+                    if ((level->valueCount % 2 == 0))
+                        os_->Put((writeFlags & kWriteCommasOmitted) ? ' ' : ',');
+                    else
+                        os_->Put((writeFlags & kWriteEqualReplaceColon) ? '=' : ':');
+                }
             }
             if (!level->inArray && level->valueCount % 2 == 0)
                 RAPIDJSON_ASSERT(type == kStringType);  // if it's in object, then even number should be a name

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -20,6 +20,7 @@ set(UNITTEST_SOURCES
     regextest.cpp
 	schematest.cpp
 	simdtest.cpp
+	sjsontest.cpp
     strfunctest.cpp
     stringbuffertest.cpp
     strtodtest.cpp

--- a/test/unittest/sjsontest.cpp
+++ b/test/unittest/sjsontest.cpp
@@ -1,0 +1,63 @@
+// Tencent is pleased to support the open source community by making RapidJSON available.
+// 
+// Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip. All rights reserved.
+//
+// Licensed under the MIT License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://opensource.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software distributed 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+
+#include "unittest.h"
+#include "rapidjson/document.h"
+#include "rapidjson/writer.h"
+#include "rapidjson/filereadstream.h"
+#include "rapidjson/encodedstream.h"
+#include "rapidjson/stringbuffer.h"
+#include <sstream>
+#include <algorithm>
+
+#ifdef __clang__
+RAPIDJSON_DIAG_PUSH
+RAPIDJSON_DIAG_OFF(c++98-compat)
+RAPIDJSON_DIAG_OFF(missing-variable-declarations)
+#endif
+
+using namespace rapidjson;
+
+TEST(Sjson, Parse) {
+    const char* sjson = "hello = \"world\"  t = true  f = false, n = null i = 123, pi = 3.1416 a = [1 2 3 4]";
+    GenericDocument<UTF8<>>  doc;
+    doc.Parse<kParseSJSONDefaultFlags>(sjson);
+    EXPECT_FALSE(doc.HasParseError());
+}
+
+TEST(Sjson, ReadSjsonWritejson) {
+    // Test writing sjson -> json.
+    StringStream s("hello = \"world\"  t = true  f = false, /* I am a comment! */ n = null i = 123, pi = 3.1416 a = [1 2 3]");
+    StringBuffer buffer;
+    Writer<StringBuffer> writer(buffer);
+    buffer.ShrinkToFit();
+    Reader reader;
+    reader.Parse<kParseSJSONDefaultFlags>(s, writer);
+    EXPECT_STREQ("{\"hello\":\"world\",\"t\":true,\"f\":false,\"n\":null,\"i\":123,\"pi\":3.1416,\"a\":[1,2,3]}", buffer.GetString());
+    EXPECT_EQ(77u, buffer.GetSize());
+    EXPECT_TRUE(writer.IsComplete());
+}
+
+TEST(Sjson, ReadSjsonWriteSjson) {
+    // Test writing sjson -> json.
+    StringStream s("hello = \"world\"  t = true  f = false, /* I am a comment! */ n = null i = 123, pi = 3.1416 a = [1 2 3]");
+    StringBuffer buffer;
+    Writer<StringBuffer, UTF8<>, UTF8<>, CrtAllocator, kWriteDefaultSJSONFlags> writer(buffer);
+    buffer.ShrinkToFit();
+    Reader reader;
+    reader.Parse<kParseSJSONDefaultFlags>(s, writer);
+    EXPECT_STREQ("hello=\"world\" t=true f=false n=null i=123 pi=3.1416 a=[1 2 3]", buffer.GetString());
+    EXPECT_EQ(61u, buffer.GetSize());
+    EXPECT_TRUE(writer.IsComplete());
+}


### PR DESCRIPTION
#1024 SJSON support.
http://help.autodesk.com/view/Stingray/ENU/?guid=__stingray_help_managing_content_sjson_html

Implements the following via Parse and Write flags:
- The equal sign is used to define key-value pairs instead of the colon :
- Quotes around strings in key-value pairs are optional
- Commas are optional in object and array definitions
- Each SJSON file is interpreted as a definition of a single object.

Allowing of comments was already implemented.