### PR TITLE
Fix Windows doc build MSBuild error MSB6001

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -10,11 +10,13 @@ ELSE()
     CONFIGURE_FILE(Doxyfile.in Doxyfile @ONLY)
     CONFIGURE_FILE(Doxyfile.zh-cn.in Doxyfile.zh-cn @ONLY)
 
+    file(GLOB DOXYFILES ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile*)
+    
     add_custom_command(OUTPUT html
         COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
         COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile.zh-cn
         COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/html
-        DEPENDS ${MARKDOWN_DOC} ${SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile*
+        DEPENDS ${MARKDOWN_DOC} ${SOURCES} ${DOXYFILES}
         WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/../
         )
 


### PR DESCRIPTION
When using a MSBuild-based CMake generator like 'Visual Studio 15 2017
Win64', the doc build was failing with the error 'MSB6001: Invalid
command line switch for "cmd.exe". Illegal characters in path.'

This was due to the dependency on Doxyfile*, which wasn't expanded by
CMake.

The fix is to expand this glob in CMake before specifying the custom
command's dependencies.

Partial fix for https://github.com/miloyip/rapidjson/issues/622