### PR TITLE
Guard against min/max being macros in a cross-compiler way

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -29,14 +29,6 @@ RAPIDJSON_DIAG_PUSH
 #ifdef _MSC_VER
 RAPIDJSON_DIAG_OFF(4127) // conditional expression is constant
 RAPIDJSON_DIAG_OFF(4244) // conversion from kXxxFlags to 'uint16_t', possible loss of data
-#ifdef _MINWINDEF_       // see: http://stackoverflow.com/questions/22744262/cant-call-stdmax-because-minwindef-h-defines-max
-#ifndef NOMINMAX
-#pragma push_macro("min")
-#pragma push_macro("max")
-#undef min
-#undef max
-#endif
-#endif
 #endif
 
 #ifdef __clang__
@@ -1018,14 +1010,14 @@ public:
             uint64_t u = GetUint64();
             volatile double d = static_cast<double>(u);
             return (d >= 0.0)
-                && (d < static_cast<double>(std::numeric_limits<uint64_t>::max()))
+                && (d < static_cast<double>((std::numeric_limits<uint64_t>::max)()))
                 && (u == static_cast<uint64_t>(d));
         }
         if (IsInt64()) {
             int64_t i = GetInt64();
             volatile double d = static_cast<double>(i);
-            return (d >= static_cast<double>(std::numeric_limits<int64_t>::min()))
-                && (d < static_cast<double>(std::numeric_limits<int64_t>::max()))
+            return (d >= static_cast<double>((std::numeric_limits<int64_t>::min)()))
+                && (d < static_cast<double>((std::numeric_limits<int64_t>::max)()))
                 && (i == static_cast<int64_t>(d));
         }
         return true; // double, int, uint are always lossless
@@ -1042,8 +1034,8 @@ public:
     bool IsLosslessFloat() const {
         if (!IsNumber()) return false;
         double a = GetDouble();
-        if (a < static_cast<double>(-std::numeric_limits<float>::max())
-                || a > static_cast<double>(std::numeric_limits<float>::max()))
+        if (a < static_cast<double>(-(std::numeric_limits<float>::max)())
+                || a > static_cast<double>((std::numeric_limits<float>::max)()))
             return false;
         double b = static_cast<double>(static_cast<float>(a));
         return a >= b && a <= b;    // Prevent -Wfloat-equal
@@ -2616,12 +2608,6 @@ private:
 };
 
 RAPIDJSON_NAMESPACE_END
-#ifdef _MINWINDEF_       // see: http://stackoverflow.com/questions/22744262/cant-call-stdmax-because-minwindef-h-defines-max
-#ifndef NOMINMAX
-#pragma pop_macro("min")
-#pragma pop_macro("max")
-#endif
-#endif
 RAPIDJSON_DIAG_POP
 
 #endif // RAPIDJSON_DOCUMENT_H_

--- a/test/unittest/itoatest.cpp
+++ b/test/unittest/itoatest.cpp
@@ -70,8 +70,8 @@ template <typename T>
 static void Verify(void(*f)(T, char*), char* (*g)(T, char*)) {
     // Boundary cases
     VerifyValue<T>(0, f, g);
-    VerifyValue<T>(std::numeric_limits<T>::min(), f, g);
-    VerifyValue<T>(std::numeric_limits<T>::max(), f, g);
+    VerifyValue<T>((std::numeric_limits<T>::min)(), f, g);
+    VerifyValue<T>((std::numeric_limits<T>::max)(), f, g);
 
     // 2^n - 1, 2^n, 10^n - 1, 10^n until overflow
     for (int power = 2; power <= 10; power += 8) {

--- a/test/unittest/readertest.cpp
+++ b/test/unittest/readertest.cpp
@@ -415,7 +415,7 @@ TEST(Reader, ParseNumber_NormalPrecisionError) {
         uint64_t bias1 = e.ToBias();
         uint64_t bias2 = a.ToBias();
         double ulp = static_cast<double>(bias1 >= bias2 ? bias1 - bias2 : bias2 - bias1);
-        ulpMax = std::max(ulpMax, ulp);
+        ulpMax = (std::max)(ulpMax, ulp);
         ulpSum += ulp;
     }
     printf("ULP Average = %g, Max = %g \n", ulpSum / count, ulpMax);

--- a/test/unittest/strtodtest.cpp
+++ b/test/unittest/strtodtest.cpp
@@ -91,7 +91,7 @@ TEST(Strtod, CheckApproximationCase) {
     }
 
     // Remove common power of two factor from all three scaled values
-    int common_Exp2 = std::min(dS_Exp2, std::min(bS_Exp2, hS_Exp2));
+    int common_Exp2 = (std::min)(dS_Exp2, (std::min)(bS_Exp2, hS_Exp2));
     dS_Exp2 -= common_Exp2;
     bS_Exp2 -= common_Exp2;
     hS_Exp2 -= common_Exp2;


### PR DESCRIPTION
Guards against min/max being macros.

Sometimes, particularly when Microsoft's windows.h is included, min/max are defined as macros, interfering with use of std::numeric_limits::min() and the like.  To guard against this, the function name is wrapped in an extra set of parenthesis, which inhibits function-style macro expansion.

Two separate commits here: one for document.h and one for test code.