### PR TITLE
Add a pointer argument to GenericSchemaDocument constructor.

### DIFF
--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -1774,7 +1774,7 @@ private:
                 }
                 else { // Local reference
                     const PointerType pointer(s, len, allocator_);
-                    if (pointer.IsValid()) {
+                    if (pointer.IsValid() && !IsCyclicRef(pointer)) {
                         if (const ValueType* nv = pointer.Get(document)) {
                             CreateSchema(schema, pointer, *nv, document);
                             return true;
@@ -1797,6 +1797,13 @@ private:
             SchemaEntry *entry = schemaMap_.template Push<SchemaEntry>();
             new (entry) SchemaEntry(**ref, schema, false, allocator_);
         }
+    }
+
+    bool IsCyclicRef(const PointerType& pointer) const {
+        for (const SchemaRefPtr* ref = schemaRef_.template Bottom<SchemaRefPtr>(); ref != schemaRef_.template End<SchemaRefPtr>(); ++ref)
+            if (pointer == **ref)
+                return true;
+        return false;
     }
 
     const SchemaType* GetSchema(const PointerType& pointer) const {


### PR DESCRIPTION
A `Document` can embed JSON schemas but not be a schema itself as a whole (e.g. a Swagger file, see sample below).

This PR allows to create a `SchemaDocument` from a `Pointer` into the source `Document` (some schema part), while local `$ref`s still resolve from the root of the source `Document`.

For instance, with the below swagger sample (approximative):
```json
{
  "swagger": "2.0",
  "paths": {
    "/some/path": {
      "post": {
        "parameters": [
          {
            "in": "body",
            "name": "body",
            "schema": {
              "properties": {
                "a": {
                  "$ref": "#/definitions/SomeBodyPropertySchema"
                },
                "b": {
                  "type": "string"
                }
              },
              "type": "object"
            }
          }
        ],
        "responses": {
          "200": {
            "schema": {
              "$ref": "#/definitions/SomeResponseSchema"
            }
          }
        }
      }
    }
  },
  "definitions": {
    "SomeBodyPropertySchema": {
      "properties": {
        "e": {
          "enum": [
            "X",
            "Y",
            "Z"
          ],
          "type": "string"
        }
      },
      "type": "object"
    },
    "SomeResponseSchema": {
      "properties": {
        "c": {
          "type": "string"
        },
        "d": {
          "type": "string"
        },
      },
      "type": "object"
    }
  }
}
```

One can:
```C++
Document swagger;
swagger.Parse(above_json);

SchemaDocument schema1{swagger, NULL, 0, NULL, NULL, Pointer("#~1some~1path/post/parameters/0/schema")};
SchemaDocument schema2{swagger, NULL, 0, NULL, NULL, Pointer("#~1some~1path/post/responses/200/schema")};
```

For the change to be minimal, this first proposed patch adds an optional `Pointer` argument (lastly) to the existing `GenericSchemaDocument` constructor.
It may be easier for the caller if a new `GenericSchemaDocument` constructor with a non optional `Pointer` as second argument were provided, to avoid the NULLs and zeros above...