### PR TITLE
Fix warning when NDEBUG is defined [-Wunused-variable]

### DIFF
--- a/include/rapidjson/writer.h
+++ b/include/rapidjson/writer.h
@@ -460,8 +460,7 @@ protected:
         PutReserve(*os_, length);
         GenericStringStream<SourceEncoding> is(json);
         while (RAPIDJSON_LIKELY(is.Tell() < length)) {
-            const Ch c = is.Peek();
-            RAPIDJSON_ASSERT(c != '\0');
+            RAPIDJSON_ASSERT(is.Peek() != '\0');
             if (RAPIDJSON_UNLIKELY(!(writeFlags & kWriteValidateEncodingFlag ? 
                 Transcoder<SourceEncoding, TargetEncoding>::Validate(is, *os_) :
                 Transcoder<SourceEncoding, TargetEncoding>::TranscodeUnsafe(is, *os_))))


### PR DESCRIPTION
Because `isPeek()` is side effect free this should not change anything.

The reason this warning is not shown in the unit tests is because the asserts
are always evaluated in the unit test:

#define RAPIDJSON_ASSERT(x) (!(x) ? throw AssertException(RAPIDJSON_STRINGIFY(x)) : (void)0u)