### PR TITLE
CMake: Canonicalize rapidjson include path in RapidJSONConfig.cmake.

### DIFF
--- a/RapidJSONConfig.cmake.in
+++ b/RapidJSONConfig.cmake.in
@@ -10,6 +10,8 @@ set( RapidJSON_DIR "@CONFIG_DIR@")
 # Compute paths
 get_filename_component(RapidJSON_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 
-set( RapidJSON_INCLUDE_DIR  "@RapidJSON_INCLUDE_DIR@" )
-set( RapidJSON_INCLUDE_DIRS  "@RapidJSON_INCLUDE_DIR@" )
+# Canonicalize relative path
+get_filename_component(RapidJSON_INCLUDE_DIR "@RapidJSON_INCLUDE_DIR@" REALPATH)
+set( RapidJSON_INCLUDE_DIRS "${RapidJSON_INCLUDE_DIR}" )
+
 message(STATUS "RapidJSON found. Headers: ${RapidJSON_INCLUDE_DIRS}")


### PR DESCRIPTION
Having the path without relative components allows other projects to add the
RadidJSON_INCLUDE_DIRS as a system include directory, without causing problems
in the build.