### PR TITLE
Fix build errors when googletest is built

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,11 @@ option(RAPIDJSON_BUILD_TESTS "Build rapidjson perftests and unittests." ON)
 option(RAPIDJSON_BUILD_THIRDPARTY_GTEST
     "Use gtest installation in `thirdparty/gtest` by default if available" OFF)
 
+if(MSVC AND RAPIDJSON_BUILD_THIRDPARTY_GTEST)
+    set(CMAKE_CXX_FLAGS_RELEASE "/MT")
+    set(CMAKE_CXX_FLAGS_DEBUG   "/MTd")
+endif()
+
 option(RAPIDJSON_BUILD_CXX11 "Build rapidjson with C++11 (gcc/clang)" ON)
 if(RAPIDJSON_BUILD_CXX11)
     set(CMAKE_CXX_STANDARD 11)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,7 +11,8 @@ IF(GTESTSRC_FOUND)
     add_subdirectory(${GTEST_SOURCE_DIR} ${CMAKE_BINARY_DIR}/googletest)
     include_directories(SYSTEM ${GTEST_INCLUDE_DIR})
 
-    set(TEST_LIBRARIES gtest gtest_main)
+    set_target_properties(gtest PROPERTIES FOLDER "${GTEST_SOURCE_DIR}")
+    set_target_properties(gtest_main PROPERTIES FOLDER "${GTEST_SOURCE_DIR}")
 
     add_custom_target(tests ALL)
     add_subdirectory(perftest)

--- a/test/perftest/CMakeLists.txt
+++ b/test/perftest/CMakeLists.txt
@@ -6,7 +6,7 @@ set(PERFTEST_SOURCES
     schematest.cpp)
 
 add_executable(perftest ${PERFTEST_SOURCES})
-target_link_libraries(perftest ${TEST_LIBRARIES})
+target_link_libraries(perftest gtest gtest_main)
 
 add_dependencies(tests perftest)
 

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -69,7 +69,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DRAPIDJSON_HAS_STDSTRING=1")
 add_library(namespacetest STATIC namespacetest.cpp)
 
 add_executable(unittest ${UNITTEST_SOURCES})
-target_link_libraries(unittest ${TEST_LIBRARIES} namespacetest)
+target_link_libraries(unittest gtest gtest_main namespacetest)
 
 add_dependencies(tests unittest)
 


### PR DESCRIPTION
Fix #1515.
1. Tell CMake that the tests should depend on `googletest`;
2. If `RAPIDJSON_BUILD_THIRDPARTY_GTEST` is set and `MSVC`, set the compile flag with `/MT` and `/MTd`