### PR TITLE
avoid gcc parse errors

### DIFF
--- a/include/rapidjson/pointer.h
+++ b/include/rapidjson/pointer.h
@@ -404,7 +404,7 @@ public:
                 return tokens_[i].index < rhs.tokens_[i].index;
 
             if (tokens_[i].length != rhs.tokens_[i].length)
-                return tokens_[i].length < rhs.tokens_[i].length;
+                return (tokens_[i].length) < (rhs.tokens_[i].length);
 
             if (int cmp = std::memcmp(tokens_[i].name, rhs.tokens_[i].name, sizeof(Ch) * tokens_[i].length))
                 return cmp < 0;


### PR DESCRIPTION
I'm using rapidjson in a larger project over here: https://github.com/valhalla/valhalla

I recently updated to master so that I could make use of `RAPIDJSON_ASSERT_THROWS` which removes `clang` warnings when you override the rapidjson default `assert` behavior with a `throw` statement. In fact, clang compiles everything like a charm and now the project has no warnings, as of this PR: https://github.com/valhalla/valhalla/pull/1864. However you'll notice that the PR is failing to build on platforms that compile using `gcc`.

Specifically I'm seeing the following compiler error when including rapidjson:

```
In file included from /home/kkreiser/sandbox/valhalla/valhalla/valhalla/baldr/rapidjson_utils.h:34:0,
                 from /home/kkreiser/sandbox/valhalla/valhalla/src/mjolnir/valhalla_add_predicted_traffic.cc:9:
/home/kkreiser/sandbox/valhalla/valhalla/third_party/rapidjson/include/rapidjson/pointer.h: In member function ‘bool rapidjson::GenericPointer<ValueType, Allocator>::operator<(const rapidjson::GenericPointer<ValueType, Allocator>&) const’:
/home/kkreiser/sandbox/valhalla/valhalla/third_party/rapidjson/include/rapidjson/pointer.h:407:59: error: the value of ‘i’ is not usable in a constant expression
                 return tokens_[i].length < rhs.tokens_[i].length;
                                                           ^
/home/kkreiser/sandbox/valhalla/valhalla/third_party/rapidjson/include/rapidjson/pointer.h:402:21: note: ‘std::size_t i’ is not const
         for (size_t i = 0; i < tokenCount_; i++) {
                     ^
/home/kkreiser/sandbox/valhalla/valhalla/third_party/rapidjson/include/rapidjson/pointer.h:407:35: error: parse error in template argument list
                 return tokens_[i].length < rhs.tokens_[i].length;
```

Honestly the error seems to make almost no sense to me given the actual code in `pointer.h`. Seems like maybe some `macro-magic` is going wrong somewhere or gcc has a bug. Anyway... I found that if I simply put the operands of the less than operator in parenthesis, gcc doesn't complain.

I know this is probably not the fix the project would like use in the long run, but I've been both unable to come up with a minimal example and unable to track down the error to something else. I did see various places on the internet complaining about something similar sounding: https://gcc.gnu.org/ml/gcc-help/2016-01/msg00087.html and https://stackoverflow.com/questions/10671406/c-confusing-attribute-name-for-member-template, so I though it would be worth bringing it to your attention.