### PR TITLE
Remove CMakeLists.txt from NAMES in FIND_PATH call

### DIFF
--- a/CMakeModules/FindGTestSrc.cmake
+++ b/CMakeModules/FindGTestSrc.cmake
@@ -12,7 +12,7 @@ IF(UNIX)
 ENDIF()
 
 FIND_PATH(GTEST_SOURCE_DIR
-    NAMES CMakeLists.txt src/gtest_main.cc
+    NAMES src/gtest_main.cc
     PATHS ${GTEST_SEARCH_PATH})
 
 


### PR DESCRIPTION
FIND_PATH will search for satisfying directories in $PATH before any of
the PATHS variables (i.e. ${GTEST_SEARCH_PATH}) [1]. So if you have any
directory in your $PATH that contains a CMakeLists.txt it will be the
result.

I ran into this issue when trying to build with the vendored gtest,
since I had an unrelated directory in my $PATH that contained a
CMakeLists.txt.

[1] https://cmake.org/cmake/help/v3.17/command/find_path.html