### PR TITLE
Fix compilation on platforms without std::wistream or std::wostream

### DIFF
--- a/include/rapidjson/internal/strfunc.h
+++ b/include/rapidjson/internal/strfunc.h
@@ -40,10 +40,12 @@ inline SizeType StrLen(const char* s) {
     return SizeType(std::strlen(s));
 }
 
+#if RAPIDJSON_HAS_WCHAR_FUNCTIONS
 template <>
 inline SizeType StrLen(const wchar_t* s) {
     return SizeType(std::wcslen(s));
 }
+#endif
 
 //! Returns number of code points in a encoded string.
 template<typename Encoding>

--- a/include/rapidjson/istreamwrapper.h
+++ b/include/rapidjson/istreamwrapper.h
@@ -117,7 +117,9 @@ private:
 };
 
 typedef BasicIStreamWrapper<std::istream> IStreamWrapper;
+#if RAPIDJSON_HAS_WCHAR_FUNCTIONS
 typedef BasicIStreamWrapper<std::wistream> WIStreamWrapper;
+#endif
 
 #if defined(__clang__) || defined(_MSC_VER)
 RAPIDJSON_DIAG_POP

--- a/include/rapidjson/ostreamwrapper.h
+++ b/include/rapidjson/ostreamwrapper.h
@@ -70,7 +70,9 @@ private:
 };
 
 typedef BasicOStreamWrapper<std::ostream> OStreamWrapper;
+#if RAPIDJSON_HAS_WCHAR_FUNCTIONS
 typedef BasicOStreamWrapper<std::wostream> WOStreamWrapper;
+#endif
 
 #ifdef __clang__
 RAPIDJSON_DIAG_POP

--- a/include/rapidjson/rapidjson.h
+++ b/include/rapidjson/rapidjson.h
@@ -210,6 +210,19 @@
 #endif // RAPIDJSON_NO_INT64TYPEDEF
 
 ///////////////////////////////////////////////////////////////////////////////
+// RAPIDJSON_HAS_WCHAR_FUNCTIONS
+
+#ifndef RAPIDJSON_HAS_WCHAR_FUNCTIONS
+//!@cond RAPIDJSON_HIDDEN_FROM_DOXYGEN
+#if defined(__GLIBCXX__) && !defined(_GLIBCXX_USE_WCHAR_T)
+#define RAPIDJSON_HAS_WCHAR_FUNCTIONS 0
+#else
+#define RAPIDJSON_HAS_WCHAR_FUNCTIONS 1
+#endif
+//!@endcond
+#endif // RAPIDJSON_HAS_WCHAR_FUNCTIONS
+
+///////////////////////////////////////////////////////////////////////////////
 // RAPIDJSON_FORCEINLINE
 
 #ifndef RAPIDJSON_FORCEINLINE


### PR DESCRIPTION
Support for wchar_t functionality is not provided in libstdc++ if only partial support is provided by the C library. This is needed to support compiling for RISC OS.