### PR TITLE
Fix constexpr error when compiling using /W4 + /WX flags for MVC and C++17

### DIFF
--- a/include/rapidjson/pointer.h
+++ b/include/rapidjson/pointer.h
@@ -303,7 +303,7 @@ public:
         SizeType length = static_cast<SizeType>(end - buffer);
         buffer[length] = '\0';
 
-        if (sizeof(Ch) == 1) {
+        if RAPIDJSON_CONSTEXPR (sizeof(Ch) == 1) {
             Token token = { reinterpret_cast<Ch*>(buffer), length, index };
             return Append(token, allocator);
         }

--- a/include/rapidjson/rapidjson.h
+++ b/include/rapidjson/rapidjson.h
@@ -650,6 +650,12 @@ RAPIDJSON_NAMESPACE_END
 #endif
 
 #if RAPIDJSON_HAS_CXX17
+# define RAPIDJSON_CONSTEXPR constexpr
+#else
+# define RAPIDJSON_CONSTEXPR
+#endif
+
+#if RAPIDJSON_HAS_CXX17
 # define RAPIDJSON_DELIBERATE_FALLTHROUGH [[fallthrough]]
 #elif defined(__has_cpp_attribute)
 # if __has_cpp_attribute(clang::fallthrough)

--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -1571,7 +1571,7 @@ struct TokenHelper {
 template <typename Stack>
 struct TokenHelper<Stack, char> {
     RAPIDJSON_FORCEINLINE static void AppendIndexToken(Stack& documentStack, SizeType index) {
-        if (sizeof(SizeType) == 4) {
+        if RAPIDJSON_CONSTEXPR (sizeof(SizeType) == 4) {
             char *buffer = documentStack.template Push<char>(1 + 10); // '/' + uint
             *buffer++ = '/';
             const char* end = internal::u32toa(index, buffer);


### PR DESCRIPTION
Fix constexpr build error when compiling using /W4 + /WX flag for MVC and C++17