### PR TITLE
fix: make errors

### DIFF
--- a/include/rapidjson/internal/meta.h
+++ b/include/rapidjson/internal/meta.h
@@ -42,6 +42,7 @@ template <typename T> struct Void { typedef void Type; };
 // BoolType, TrueType, FalseType
 //
 template <bool Cond> struct BoolType {
+    virtual ~BoolType();
     static const bool Value = Cond;
     typedef BoolType Type;
 };


### PR DESCRIPTION
Cmake in build file to generate makefile，An error is reported when make
error is ：
base class 'struct rapidjson::internal::BoolType<true>'  have a non virtual destructor

- [ ] #2043 