### PR TITLE
Throw std::bad_alloc on malloc/realloc failure

### DIFF
--- a/include/rapidjson/allocators.h
+++ b/include/rapidjson/allocators.h
@@ -84,9 +84,13 @@ class CrtAllocator {
 public:
     static const bool kNeedFree = true;
     void* Malloc(size_t size) { 
-        if (size) //  behavior of malloc(0) is implementation defined.
-            return RAPIDJSON_MALLOC(size);
-        else
+        if (size) { //  behavior of malloc(0) is implementation defined.
+            void* ptr = RAPIDJSON_MALLOC(size);
+            if (!ptr) {
+                 RAPIDJSON_OUT_OF_MEMORY();
+            }
+            return ptr;
+        } else
             return NULL; // standardize to returning NULL.
     }
     void* Realloc(void* originalPtr, size_t originalSize, size_t newSize) {
@@ -95,7 +99,12 @@ public:
             RAPIDJSON_FREE(originalPtr);
             return NULL;
         }
-        return RAPIDJSON_REALLOC(originalPtr, newSize);
+        void* ptr = RAPIDJSON_REALLOC(originalPtr, newSize);
+        if (!ptr) {
+            RAPIDJSON_FREE(originalPtr);
+            RAPIDJSON_OUT_OF_MEMORY();
+        }
+        return ptr;
     }
     static void Free(void *ptr) RAPIDJSON_NOEXCEPT { RAPIDJSON_FREE(ptr); }
 

--- a/include/rapidjson/rapidjson.h
+++ b/include/rapidjson/rapidjson.h
@@ -703,6 +703,9 @@ RAPIDJSON_NAMESPACE_END
 ///! customization point for global \c free
 #define RAPIDJSON_FREE(ptr) std::free(ptr)
 #endif
+#ifndef RAPIDJSON_OUT_OF_MEMORY
+#define RAPIDJSON_OUT_OF_MEMORY() throw std::bad_alloc()
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 // new/delete


### PR DESCRIPTION
CodeSonar [1] complains about writing to NULL pointers inside document.h: SetObjectRaw(), SetArrayRaw(), and SetStringRaw().

[1] https://www.grammatech.com/codesonar-cc