### PR TITLE
fix missing check allocator is reference in ClearStack()

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -2866,7 +2866,8 @@ private:
     GenericDocument& operator=(const GenericDocument&);
 
     void ClearStack() {
-        if (Allocator::kNeedFree)
+        if (Allocator::kNeedFree || (RAPIDJSON_USE_MEMBERSMAP+0 &&
+                                     internal::IsRefCounted<Allocator>::Value))
             while (stack_.GetSize() > 0)    // Here assumes all elements in stack array are GenericValue (Member is actually 2 GenericValue objects)
                 (stack_.template Pop<ValueType>(1))->~ValueType();
         else


### PR DESCRIPTION
ClearStack() function in document.h misses check allocator type. This would cause memory leak if parse failed. Such as following code:
```c++
int main()
{
    if (1) {
      rapidjson::Document doc;
      auto& ret = doc.Parse<0>(R"(
        {"a":"a","b":"b"}, {"c":"c"}
      )");
    }
    return 0;
}
```