### PR TITLE
Using C++11 features and added missing asserts

### DIFF
--- a/include/rapidjson/allocators.h
+++ b/include/rapidjson/allocators.h
@@ -502,8 +502,7 @@ public:
         baseAllocator_(allocator)
     { }
 
-    ~StdAllocator() RAPIDJSON_NOEXCEPT
-    { }
+    ~StdAllocator() RAPIDJSON_NOEXCEPT = default;
 
     template<typename U>
     struct rebind {
@@ -666,8 +665,7 @@ public:
         baseAllocator_(baseAllocator)
     { }
 
-    ~StdAllocator() RAPIDJSON_NOEXCEPT
-    { }
+    ~StdAllocator() RAPIDJSON_NOEXCEPT = default;
 
     template<typename U>
     struct rebind {

--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -945,7 +945,7 @@ public:
     */
     GenericValue& operator=(StringRefType str) RAPIDJSON_NOEXCEPT {
         GenericValue s(str);
-        return *this = s;
+        return *this = std::move(s);
     }
 
     //! Assignment with primitive types.
@@ -964,7 +964,7 @@ public:
     RAPIDJSON_DISABLEIF_RETURN((internal::IsPointer<T>), (GenericValue&))
     operator=(T value) {
         GenericValue v(value);
-        return *this = v;
+        return *this = std::move(v);
     }
 
     //! Deep-copy assignment from Value
@@ -2911,7 +2911,7 @@ public:
 
     GenericArray(const GenericArray& rhs) : value_(rhs.value_) {}
     GenericArray& operator=(const GenericArray& rhs) { value_ = rhs.value_; return *this; }
-    ~GenericArray() {}
+    ~GenericArray() = default;
 
     operator ValueType&() const { return value_; }
     SizeType Size() const { return value_.Size(); }
@@ -2967,7 +2967,7 @@ public:
 
     GenericObject(const GenericObject& rhs) : value_(rhs.value_) {}
     GenericObject& operator=(const GenericObject& rhs) { value_ = rhs.value_; return *this; }
-    ~GenericObject() {}
+    ~GenericObject() = default;
 
     operator ValueType&() const { return value_; }
     SizeType MemberCount() const { return value_.MemberCount(); }

--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -1670,7 +1670,11 @@ public:
         RAPIDJSON_ASSERT(index < data_.a.size);
         return GetElementsPointer()[index];
     }
-    const GenericValue& operator[](SizeType index) const { return const_cast<GenericValue&>(*this)[index]; }
+    const GenericValue& operator[](SizeType index) const {
+        RAPIDJSON_ASSERT(IsArray());
+        RAPIDJSON_ASSERT(index < data_.a.size);
+        return const_cast<GenericValue&>(*this)[index];
+    }
 
     //! Element iterator
     /*! \pre IsArray() == true */

--- a/include/rapidjson/pointer.h
+++ b/include/rapidjson/pointer.h
@@ -557,7 +557,7 @@ public:
                     typename ValueType::MemberIterator m = v->FindMember(kIdValue);
                     if (m != v->MemberEnd() && (m->value).IsString()) {
                         UriType here = UriType(m->value, allocator).Resolve(base, allocator);
-                        base = here;
+                        base = std::move(here);
                     }
                     m = v->FindMember(GenericValue<EncodingType>(GenericStringRef<Ch>(t->name, t->length)));
                     if (m == v->MemberEnd())

--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -2055,13 +2055,6 @@ private:
             return dst;
 
         case IterativeParsingMemberValueState:
-            // Must be non-compound value. Or it would be ObjectInitial or ArrayInitial state.
-            ParseValue<parseFlags>(is, handler);
-            if (HasParseError()) {
-                return IterativeParsingErrorState;
-            }
-            return dst;
-
         case IterativeParsingElementState:
             // Must be non-compound value. Or it would be ObjectInitial or ArrayInitial state.
             ParseValue<parseFlags>(is, handler);

--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -173,7 +173,7 @@ public:
 template <typename SchemaType>
 class ISchemaStateFactory {
 public:
-    virtual ~ISchemaStateFactory() {}
+    virtual ~ISchemaStateFactory() = default;
     virtual ISchemaValidator* CreateSchemaValidator(const SchemaType&, const bool inheritContinueOnErrors) = 0;
     virtual void DestroySchemaValidator(ISchemaValidator* validator) = 0;
     virtual void* CreateHasher() = 0;
@@ -192,7 +192,7 @@ public:
     typedef typename SchemaType::Ch Ch;
     typedef typename SchemaType::SValue SValue;
 
-    virtual ~IValidationErrorHandler() {}
+    virtual ~IValidationErrorHandler() = default;
 
     virtual void NotMultipleOf(int64_t actual, const SValue& expected) = 0;
     virtual void NotMultipleOf(uint64_t actual, const SValue& expected) = 0;
@@ -1605,7 +1605,7 @@ public:
     typedef typename SchemaDocumentType::ValueType ValueType;
     typedef typename SchemaDocumentType::AllocatorType AllocatorType;
 
-    virtual ~IGenericRemoteSchemaDocumentProvider() {}
+    virtual ~IGenericRemoteSchemaDocumentProvider() = default;
     virtual const SchemaDocumentType* GetRemoteDocument(const Ch* uri, SizeType length) = 0;
     virtual const SchemaDocumentType* GetRemoteDocument(GenericUri<ValueType, AllocatorType> uri) { return GetRemoteDocument(uri.GetBaseString(), uri.GetBaseStringLength()); }
 };
@@ -2233,7 +2233,7 @@ public:
             return false;
         ValueType error(kObjectType);
         error.AddMember(GetMissingString(), currentError_, GetStateAllocator());
-        currentError_ = error;
+        currentError_ = std::move(error);
         AddCurrentError(kValidateErrorRequired);
         return true;
     }
@@ -2281,7 +2281,7 @@ public:
             return false;
         ValueType error(kObjectType);
         error.AddMember(GetErrorsString(), currentError_, GetStateAllocator());
-        currentError_ = error;
+        currentError_ = std::move(error);
         AddCurrentError(kValidateErrorDependencies);
         return true;
     }
@@ -2300,7 +2300,7 @@ public:
         ValueType error(kObjectType);
         error.AddMember(GetExpectedString(), currentError_, GetStateAllocator());
         error.AddMember(GetActualString(), ValueType(actualType, GetStateAllocator()).Move(), GetStateAllocator());
-        currentError_ = error;
+        currentError_ = std::move(error);
         AddCurrentError(kValidateErrorType);
     }
     void NotAllOf(ISchemaValidator** subvalidators, SizeType count) {


### PR DESCRIPTION
@miloyip Hi, I think you will like features.
These are different overloads and they will be called in different ways.
```cpp
GenericValue& operator[](SizeType index)
```

```cpp
const GenericValue& operator[](SizeType index) const
```