### PR TITLE
Add support of parsing INFINITY and NAN according to the standard.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ DartConfiguration.tcl
 
 # Files created by OS
 *.DS_Store
+
+# VS Code files
+.vscode

--- a/doc/dom.md
+++ b/doc/dom.md
@@ -118,7 +118,7 @@ Parse flags                   | Meaning
 `kParseCommentsFlag`          | Allow one-line `// ...` and multi-line `/* ... */` comments (relaxed JSON syntax).
 `kParseNumbersAsStringsFlag`  | Parse numerical type values as strings.
 `kParseTrailingCommasFlag`    | Allow trailing commas at the end of objects and arrays (relaxed JSON syntax).
-`kParseNanAndInfFlag`         | Allow parsing `NaN`, `Inf`, `Infinity`, `-Inf` and `-Infinity` as `double` values (relaxed JSON syntax).
+`kParseNanAndInfFlag`         | Allow parsing `NaN`, `nan`, `Inf`, `Infinity`, `inf`, `-Inf`, `-Infinity` and `-inf` as `double` values (relaxed JSON syntax).
 `kParseEscapedApostropheFlag` | Allow escaped apostrophe `\'` in strings (relaxed JSON syntax).
 
 By using a non-type template parameter, instead of a function parameter, C++ compiler can generate code which is optimized for specified combinations, improving speed, and reducing code size (if only using a single specialization). The downside is the flags needed to be determined in compile-time.

--- a/test/unittest/readertest.cpp
+++ b/test/unittest/readertest.cpp
@@ -2324,17 +2324,21 @@ TEST(Reader, ParseNanAndInfinity) {
     double nan = std::numeric_limits<double>::quiet_NaN();
     double inf = std::numeric_limits<double>::infinity();
 
+    TEST_NAN_INF("nan", nan);
     TEST_NAN_INF("NaN", nan);
-    TEST_NAN_INF("-NaN", nan);
     TEST_NAN_INF("Inf", inf);
+    TEST_NAN_INF("inf", inf);
     TEST_NAN_INF("Infinity", inf);
+    TEST_NAN_INF("infinity", inf);
     TEST_NAN_INF("-Inf", -inf);
+    TEST_NAN_INF("-inf", -inf);
     TEST_NAN_INF("-Infinity", -inf);
+    TEST_NAN_INF("-infinity", -inf);
     TEST_NAN_INF_ERROR(kParseErrorValueInvalid, "NInf", 1u);
     TEST_NAN_INF_ERROR(kParseErrorValueInvalid, "NaInf", 2u);
     TEST_NAN_INF_ERROR(kParseErrorValueInvalid, "INan", 1u);
     TEST_NAN_INF_ERROR(kParseErrorValueInvalid, "InNan", 2u);
-    TEST_NAN_INF_ERROR(kParseErrorValueInvalid, "nan", 1u);
+    TEST_NAN_INF_ERROR(kParseErrorValueInvalid, "-NaN", 1u);
     TEST_NAN_INF_ERROR(kParseErrorValueInvalid, "-nan", 1u);
     TEST_NAN_INF_ERROR(kParseErrorValueInvalid, "NAN", 1u);
     TEST_NAN_INF_ERROR(kParseErrorValueInvalid, "-Infinty", 6u);


### PR DESCRIPTION
Variables of floating point types that have non-normal values, such as `INFINITY` and `NAN`, cannot be parsed by `GenericDocument::Parse(const Ch* str)` even if the flag `kParseNanAndInfFlag` is set, and that's due to the fact that the parser tests these exceptional values against `NaN`, `Infinity`, `-Infinity`, `Inf` and `-Inf`. However, according to the standard, when converting floating point types to string, e.g. using `std::to_string(double)`, these exceptional values get converted as `nan`, `inf` or `-inf`! This pull request fixes this issue (#2099).