### PR TITLE
find GTest via find_package

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,4 +17,11 @@ IF(GTESTSRC_FOUND)
     add_subdirectory(perftest)
     add_subdirectory(unittest)
 
+ELSE(GTESTSRC_FOUND)
+    find_package(GTest 1.12.1 REQUIRED)
+
+    add_custom_target(tests ALL)
+    add_subdirectory(perftest)
+    add_subdirectory(unittest)
+
 ENDIF(GTESTSRC_FOUND)

--- a/test/perftest/CMakeLists.txt
+++ b/test/perftest/CMakeLists.txt
@@ -7,6 +7,9 @@ set(PERFTEST_SOURCES
 
 add_executable(perftest ${PERFTEST_SOURCES})
 target_link_libraries(perftest ${TEST_LIBRARIES})
+if(TARGET GTest::gtest)
+    target_link_libraries(perftest GTest::gtest GTest::gmock)
+endif()
 
 add_dependencies(tests perftest)
 

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -73,6 +73,9 @@ add_library(namespacetest STATIC namespacetest.cpp)
 
 add_executable(unittest ${UNITTEST_SOURCES})
 target_link_libraries(unittest ${TEST_LIBRARIES} namespacetest)
+if(TARGET GTest::gtest)
+    target_link_libraries(unittest GTest::gtest GTest::gmock)
+endif()
 
 add_dependencies(tests unittest)
 


### PR DESCRIPTION
This patch enables the use of GTest from more locations than `../thirdparty/gtest` and `/usr/src/gtest`.
Tested on Linux with cmake-3.25.

If `RAPIDJSON_BUILD_TESTS` is `ON` but GTest was not found by the Find-script provided in `rapidjson/CMakeModules`  this patch will try to find GTest via `find_package`.

This is useful if GTest is not installed in `/usr/src/gtest` as expected by Find script.
For example when you use `CMAKE_INSTALL_PREFIX` to install GTest and RapidJSON in a stage directory.