### PR TITLE
StringRef: remove impilcit conversion to plain CharType pointer

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -413,9 +413,6 @@ struct GenericStringRef {
 
     GenericStringRef(const GenericStringRef& rhs) : s(rhs.s), length(rhs.length) {}
 
-    //! implicit conversion to plain CharType pointer
-    operator const Ch *() const { return s; }
-
     const Ch* const s; //!< plain CharType pointer
     const SizeType length; //!< length of the string (excluding the trailing NULL terminator)
 
@@ -2434,7 +2431,7 @@ private:
     //! Initialize this value as constant string, without calling destructor.
     void SetStringRaw(StringRefType s) RAPIDJSON_NOEXCEPT {
         data_.f.flags = kConstStringFlag;
-        SetStringPointer(s);
+        SetStringPointer(s.s);
         data_.s.length = s.length;
     }
 
@@ -2451,7 +2448,7 @@ private:
             str = static_cast<Ch *>(allocator.Malloc((s.length + 1) * sizeof(Ch)));
             SetStringPointer(str);
         }
-        std::memcpy(str, s, s.length * sizeof(Ch));
+        std::memcpy(str, s.s, s.length * sizeof(Ch));
         str[s.length] = '\0';
     }
 

--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -842,6 +842,9 @@ public:
     //! Constructor for copy-string (i.e. do make a copy of string)
     GenericValue(const Ch*s, Allocator& allocator) : data_() { SetStringRaw(StringRef(s), allocator); }
 
+    //! Constructor for copy-string (i.e. do make a copy of string)
+    GenericValue(StringRefType s, Allocator& allocator) : data_() { SetStringRaw(s, allocator); }
+
 #if RAPIDJSON_HAS_STDSTRING
     //! Constructor for copy-string from a string object (i.e. do make a copy of string)
     /*! \note Requires the definition of the preprocessor symbol \ref RAPIDJSON_HAS_STDSTRING.
@@ -1595,6 +1598,16 @@ public:
         RAPIDJSON_ASSERT(first <= last);
         RAPIDJSON_ASSERT(last <= MemberEnd());
         return DoEraseMembers(first, last);
+    }
+
+    //! Erase a member in object by its name.
+    /*! \param name Name of member to be removed.
+        \return Whether the member existed.
+        \note Linear time complexity.
+    */
+    bool EraseMember(StringRefType name) {
+        GenericValue n(name);
+        return EraseMember(n);
     }
 
     //! Erase a member in object by its name.

--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -2560,7 +2560,7 @@ public:
     //  If reporting all errors, the stack will be empty, so return "errors".
     const Ch* GetInvalidSchemaKeyword() const {
         if (!schemaStack_.Empty()) return CurrentContext().invalidKeyword;
-        if (GetContinueOnErrors() && !error_.ObjectEmpty()) return (const Ch*)GetErrorsString();
+        if (GetContinueOnErrors() && !error_.ObjectEmpty()) return (const Ch*)GetErrorsString().s;
         return 0;
     }
 


### PR DESCRIPTION
It's too dangerous to use CharType pointer without length because there is no guaranty the string is null terminated.