### PR TITLE
Fixed forward declaration of PutUnsafe

### DIFF
--- a/include/rapidjson/encodings.h
+++ b/include/rapidjson/encodings.h
@@ -83,6 +83,10 @@ concept Encoding {
 \endcode
 */
 
+// Forward declaration.
+template<typename Stream>
+inline void PutUnsafe(Stream& stream, typename Stream::Ch c);
+
 ///////////////////////////////////////////////////////////////////////////////
 // UTF8
 
@@ -681,10 +685,6 @@ struct Transcoder {
         return Transcode(is, os);   // Since source/target encoding is different, must transcode.
     }
 };
-
-// Forward declaration.
-template<typename Stream>
-inline void PutUnsafe(Stream& stream, typename Stream::Ch c);
 
 //! Specialization of Transcoder with same source and target encoding.
 template<typename Encoding>


### PR DESCRIPTION
The PutUnsafe() function can be found via ADL lookup.
If ADL lookup rules do not apply, the default implementation of PutUnsafe() is used. The default implementation is a template that
should be predeclared in the rapidjson namespace before the first use.