### PR TITLE
Use "constexpr if" when possible

### DIFF
--- a/include/rapidjson/pointer.h
+++ b/include/rapidjson/pointer.h
@@ -291,7 +291,7 @@ public:
         SizeType length = static_cast<SizeType>(end - buffer);
         buffer[length] = '\0';
 
-        if (sizeof(Ch) == 1) {
+        RAPIDJSON_CONSTEXPR_IF (sizeof(Ch) == 1) {
             Token token = { reinterpret_cast<Ch*>(buffer), length, index };
             return Append(token, allocator);
         }

--- a/include/rapidjson/rapidjson.h
+++ b/include/rapidjson/rapidjson.h
@@ -663,6 +663,12 @@ RAPIDJSON_NAMESPACE_END
 # define RAPIDJSON_DELIBERATE_FALLTHROUGH
 #endif
 
+#if RAPIDJSON_HAS_CXX17
+# define RAPIDJSON_CONSTEXPR_IF if constexpr
+#else
+# define RAPIDJSON_CONSTEXPR_IF if
+#endif
+
 //!@endcond
 
 //! Assertion (in non-throwing contexts).

--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -1762,7 +1762,7 @@ struct TokenHelper {
 template <typename Stack>
 struct TokenHelper<Stack, char> {
     RAPIDJSON_FORCEINLINE static void AppendIndexToken(Stack& documentStack, SizeType index) {
-        if (sizeof(SizeType) == 4) {
+        RAPIDJSON_CONSTEXPR_IF (sizeof(SizeType) == 4) {
             char *buffer = documentStack.template Push<char>(1 + 10); // '/' + uint
             *buffer++ = '/';
             const char* end = internal::u32toa(index, buffer);


### PR DESCRIPTION
One more c++ 17 feature. Defined macro in rapidjson.h.