### PR TITLE
Export into the build tree the installed targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,7 +207,10 @@ install(FILES readme.md
 # Add an interface target to export it
 add_library(RapidJSON INTERFACE)
 
-target_include_directories(RapidJSON INTERFACE $<INSTALL_INTERFACE:include/rapidjson>)
+target_include_directories(RapidJSON
+    INTERFACE
+    $<INSTALL_INTERFACE:include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>)
 
 install(DIRECTORY include/rapidjson
     DESTINATION "${INCLUDE_INSTALL_DIR}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,5 +265,7 @@ IF(CMAKE_INSTALL_DIR)
         COMPONENT dev)
 
     INSTALL(TARGETS RapidJSON EXPORT RapidJSON-targets)
+    # Generate the export targets for the build tree
+    EXPORT(EXPORT RapidJSON-targets)
     INSTALL(EXPORT RapidJSON-targets DESTINATION ${CMAKE_INSTALL_DIR})
 ENDIF()

--- a/RapidJSONConfig.cmake.in
+++ b/RapidJSONConfig.cmake.in
@@ -15,8 +15,5 @@ set( RapidJSON_DIR "@CONFIG_DIR@")
 get_filename_component(RapidJSON_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 
 get_target_property(RapidJSON_INCLUDE_DIR RapidJSON INTERFACE_INCLUDE_DIRECTORIES)
-if (NOT RapidJSON_INCLUDE_DIR)
-    set(RapidJSON_INCLUDE_DIR "${RapidJSON_SOURCE_DIR}/include/rapidjson")
-endif()
 
 set( RapidJSON_INCLUDE_DIRS ${RapidJSON_INCLUDE_DIR} )

--- a/RapidJSONConfig.cmake.in
+++ b/RapidJSONConfig.cmake.in
@@ -15,5 +15,8 @@ set( RapidJSON_DIR "@CONFIG_DIR@")
 get_filename_component(RapidJSON_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 
 get_target_property(RapidJSON_INCLUDE_DIR RapidJSON INTERFACE_INCLUDE_DIRECTORIES)
+if (NOT RapidJSON_INCLUDE_DIR)
+    set(RapidJSON_INCLUDE_DIR "${RapidJSON_SOURCE_DIR}/include/rapidjson")
+endif()
 
 set( RapidJSON_INCLUDE_DIRS ${RapidJSON_INCLUDE_DIR} )


### PR DESCRIPTION
Currently the CMake is modifying the [CMake user's package registry](https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#user-package-registry) by doing:
```cmake
# Export package for use from the build tree
EXPORT( PACKAGE ${PROJECT_NAME} )
```
the above hints the binary directory as a path to find a config dir. Accordingly the config is set up and made available via:
```cmake
INCLUDE(CMakePackageConfigHelpers)
CONFIGURE_FILE( ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}Config.cmake.in
    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake @ONLY )
CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}ConfigVersion.cmake.in
    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake @ONLY)
```
unfortunately the config file reference the targets which are not installed in the build tree. This makes projects that find *RapidJSON* using the user's package registry (it must be disabled on purpose) fail because the target file cannot be found.
This pull request exports the targets installed.