### PR TITLE
Allow custom stack allocator to have non-static Free function

### DIFF
--- a/include/rapidjson/internal/stack.h
+++ b/include/rapidjson/internal/stack.h
@@ -101,7 +101,7 @@ public:
     void ShrinkToFit() { 
         if (Empty()) {
             // If the stack is empty, completely deallocate the memory.
-            Allocator::Free(stack_); // NOLINT (+clang-analyzer-unix.Malloc)
+            allocator_->Free(stack_); // NOLINT (+clang-analyzer-unix.Malloc)
             stack_ = 0;
             stackTop_ = 0;
             stackEnd_ = 0;
@@ -206,7 +206,8 @@ private:
     }
 
     void Destroy() {
-        Allocator::Free(stack_);
+        if (allocator_)
+            allocator_->Free(stack_);
         RAPIDJSON_DELETE(ownAllocator_); // Only delete if it is owned by the stack
     }
 


### PR DESCRIPTION
Changes some calls to `Allocator::Free` to call Free as a member function instead so that it works if the Free function is non-static.  Null-check in Destroy because the allocator may be null in the destructor if the Stack was moved.