### PR TITLE
Add exclusion for gtest in platformIO library.json

### DIFF
--- a/library.json
+++ b/library.json
@@ -7,8 +7,10 @@
     "include": "include"
   },
   "examples": "example/*/*.cpp",
-  "repository":
-  {
+  "build":{
+    "srcFilter": "-<thirdparty/gtest/**>"
+  },
+  "repository":{
     "type": "git",
     "url": "https://github.com/Tencent/rapidjson"
   }


### PR DESCRIPTION
When adding as a libdep on commit in platformio it is submodule initing the gtest folder and causing
it to be added as source.

This change ensures we never treat googletest as source in parent projects