### PR TITLE
fix(cmake): Add missing POST_BUILD option to travis_doc target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,7 @@ endif()
 
 add_custom_target(travis_doc)
 add_custom_command(TARGET travis_doc
+    POST_BUILD
     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/travis-doxygen.sh)
 
 if(RAPIDJSON_BUILD_EXAMPLES)


### PR DESCRIPTION
This addresses the following warning associated with CMP0175 policy introduced in CMake 3.31:

```
CMake Warning (dev) at CMakeLists.txt:165 (add_custom_command):
  Exactly one of PRE_BUILD, PRE_LINK, or POST_BUILD must be given.  Assuming
  POST_BUILD to preserve backward compatibility.

  Policy CMP0175 is not set: add_custom_command() rejects invalid arguments.
  Run "cmake --help-policy CMP0175" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.
```