### PR TITLE
Correct the behaviors of WriteBuffer

### DIFF
--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -357,7 +357,11 @@ public:
     }
 
     bool String(const Ch* str, SizeType len, bool) {
-        WriteBuffer(kStringType, str, len * sizeof(Ch));
+        if (len == 0) {
+            WriteType(kStringType);
+        } else {
+            WriteBuffer(kStringType, str, len * sizeof(Ch));
+        }
         return true;
     }
 
@@ -401,18 +405,26 @@ private:
         double d;
     };
 
-    bool WriteType(Type type) { return WriteBuffer(type, 0, 0); }
-    
-    bool WriteNumber(const Number& n) { return WriteBuffer(kNumberType, &n, sizeof(n)); }
-    
-    bool WriteBuffer(Type type, const void* data, size_t len) {
-        // FNV-1a from http://isthe.com/chongo/tech/comp/fnv/
+    bool WriteType(Type type) {
         uint64_t h = Hash(RAPIDJSON_UINT64_C2(0xcbf29ce4, 0x84222325), type);
-        const unsigned char* d = static_cast<const unsigned char*>(data);
-        for (size_t i = 0; i < len; i++)
-            h = Hash(h, d[i]);
         *stack_.template Push<uint64_t>() = h;
         return true;
+    }
+    
+    bool WriteNumber(const Number& n) { return WriteBuffer(kNumberType, &n, sizeof(n)); }
+
+    bool WriteBuffer(Type type, const void* data, size_t len) {
+        // FNV-1a from http://isthe.com/chongo/tech/comp/fnv/
+        if (data != NULL && len != 0) {
+            uint64_t h = Hash(RAPIDJSON_UINT64_C2(0xcbf29ce4, 0x84222325), type);
+            const unsigned char* d = static_cast<const unsigned char*>(data);
+            for (size_t i = 0; i < len; i++)
+                h = Hash(h, d[i]);
+            *stack_.template Push<uint64_t>() = h;
+            return true;
+        } else {
+            return false;
+        }
     }
 
     static uint64_t Hash(uint64_t h, uint64_t d) {


### PR DESCRIPTION
WriteBuffer attempt to dereference a pointer without any check. Adds a safeguard to prevent dereferencing a null pointer to fix it and nullPointer warning detected by cppcheck.

Besides, WriteBuffer always does hashing and returns true. According to the reference of FNV-1a for Hash algorithm, the original code uses a while loop to iterate over the buffer, checking that the current position is less than the end. WriteBuffer should not do hashing when the length is 0.