### PR TITLE
fix: error in `FindPropertyIndex` for non-string dependencies elements

### DIFF
--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -729,7 +729,7 @@ public:
                         std::memset(properties_[sourceIndex].dependencies, 0, sizeof(bool)* propertyCount_);
                         for (ConstValueIterator targetItr = itr->value.Begin(); targetItr != itr->value.End(); ++targetItr) {
                             SizeType targetIndex;
-                            if (FindPropertyIndex(*targetItr, &targetIndex))
+                            if (targetItr->IsString() && FindPropertyIndex(*targetItr, &targetIndex))
                                 properties_[sourceIndex].dependencies[targetIndex] = true;
                         }
                     }

--- a/test/unittest/schematest.cpp
+++ b/test/unittest/schematest.cpp
@@ -3573,6 +3573,18 @@ TEST(SchemaValidator, NullableFalse) {
         "}}");
 }
 
+TEST(SchemaValidator, DependenciesNonStringArrayElementCrash) {
+    Document sd;
+    sd.Parse("{\"properties\":{\"a\":{}},\"dependencies\":{\"a\":[0,2]}}");
+    ASSERT_FALSE(sd.HasParseError());
+    SchemaDocument schema(sd);  // must not crash
+    SchemaValidator validator(schema);
+    Document doc;
+    doc.Parse("{\"a\":1}");
+    ASSERT_FALSE(doc.HasParseError());
+    doc.Accept(validator);  // result doesn't matter — must not crash
+}
+
 #if defined(_MSC_VER) || defined(__clang__)
 RAPIDJSON_DIAG_POP
 #endif


### PR DESCRIPTION
## What is this PR?

This PR fixes a crash that I encountered.

`Schema::Schema` processes dependencies arrays by calling `FindPropertyIndex` on each element to look up property names. `FindPropertyIndex` calls `GetStringLength`, which asserts `IsString`, but the spec does not forbid non-string elements in a dependencies array, so a schema like `{"dependencies":{"a":[0,2]}}` caused an assertion failure (`SIGABRT`).

This PR fixes it by checking `targetItr->IsString()` and adds a regression test. 

```
...
#8 0x7f1dde652e95 in __assert_fail (/lib/x86_64-linux-gnu/libc.so.6+0x39e95) (BuildId: 095c7ba148aeca81668091f718047078d57efddb)
#9 0x55c7ae2e0360 in rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> >::GetStringLength() const /home/user/rapidjson/include/rapidjson/document.h:1858:40
#10 0x55c7ae2df16a in rapidjson::internal::Schema<rapidjson::GenericSchemaDocument<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> >, rapidjson::CrtAllocator> >::FindPropertyIndex(rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > const&, unsigned int*) const /home/user/rapidjson/include/rapidjson/schema.h:1518:29
#11 0x55c7ae2d1a1b in rapidjson::internal::Schema<rapidjson::GenericSchemaDocument<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> >, rapidjson::CrtAllocator> >::Schema(rapidjson::GenericSchemaDocument<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> >, rapidjson::CrtAllocator>*, rapidjson::GenericPointer<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> >, rapidjson::CrtAllocator> const&, rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > const&, rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > const&, rapidjson::CrtAllocator*, rapidjson::GenericUri<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> >, rapidjson::CrtAllocator> const&) /home/user/rapidjson/include/rapidjson/schema.h:740:33
#12 0x55c7ae2d6996 in rapidjson::GenericSchemaDocument<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> >, rapidjson::CrtAllocator>::CreateSchema(rapidjson::internal::Schema<rapidjson::GenericSchemaDocument<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> >, rapidjson::CrtAllocator> > const**, rapidjson::GenericPointer<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> >, rapidjson::CrtAllocator> const&, rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > const&, rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > const&, rapidjson::GenericUri<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> >, rapidjson::CrtAllocator> const&) /home/user/rapidjson/include/rapidjson/schema.h:2197:78
#13 0x55c7ae2d6103 in rapidjson::GenericSchemaDocument<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> >, rapidjson::CrtAllocator>::CreateSchemaRecursive(rapidjson::internal::Schema<rapidjson::GenericSchemaDocument<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> >, rapidjson::CrtAllocator> > const**, rapidjson::GenericPointer<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> >, rapidjson::CrtAllocator> const&, rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > const&, rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > const&, rapidjson::GenericUri<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> >, rapidjson::CrtAllocator> const&) /home/user/rapidjson/include/rapidjson/schema.h:2173:37
#14 0x55c7ae2c00a2 in rapidjson::GenericSchemaDocument<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> >, rapidjson::CrtAllocator>::GenericSchemaDocument(rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > const&, char const*, unsigned int, rapidjson::IGenericRemoteSchemaDocumentProvider<rapidjson::GenericSchemaDocument<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> >, rapidjson::CrtAllocator> >*, rapidjson::CrtAllocator*, rapidjson::GenericPointer<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> >, rapidjson::CrtAllocator> const&, rapidjson::Specification const&) /home/user/rapidjson/include/rapidjson/schema.h:1886:13
...
```