### PR TITLE
build: bump `cmake_minimum_required` in example

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 if(POLICY CMP0054)
   cmake_policy(SET CMP0054 NEW)


### PR DESCRIPTION
## What is this PR?

This bumps the minimum CMake version for `example` because it is making AppVeyor unhappy. 

Builds are failing on my other PRs ([example](https://ci.appveyor.com/project/miloyip/rapidjson-0fdqj/builds/53947082)) with this error message.

```
Build started
git clone -q https://github.com/Tencent/rapidjson.git C:\projects\rapidjson-0fdqj
git fetch -q origin +refs/pull/2378/merge:
git checkout -qf FETCH_HEAD
git submodule update --init --recursive
Submodule 'thirdparty/gtest' (https://github.com/google/googletest.git) registered for path 'thirdparty/gtest'
Cloning into 'C:/projects/rapidjson-0fdqj/thirdparty/gtest'...
Submodule path 'thirdparty/gtest': checked out 'ba96d0b1161f540656efdaed035b3c062b60e006'
cmake -H. -BBuild/VS -G "Visual Studio %VS_VERSION%" -DCMAKE_GENERATOR_PLATFORM=%VS_PLATFORM% -DCMAKE_VERBOSE_MAKEFILE=ON -DBUILD_SHARED_LIBS=true -DRAPIDJSON_BUILD_CXX11=%CXX11% -DRAPIDJSON_BUILD_CXX17=%CXX17% -DRAPIDJSON_BUILD_CXX20=%CXX20% -DRAPIDJSON_USE_MEMBERSMAP=%MEMBERSMAP% -Wno-dev
-- The CXX compiler identification is MSVC 19.29.30159.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.29.30133/bin/Hostx64/x64/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found Doxygen: C:/Tools/Doxygen/doxygen.exe (found version "1.14.0") found components: doxygen dot
CMake Error at example/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.
  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
-- Configuring incomplete, errors occurred!
```